### PR TITLE
Adds ToJSON to the AntDevice. 

### DIFF
--- a/AntPlus.UnitTests/AntDeviceTests.cs
+++ b/AntPlus.UnitTests/AntDeviceTests.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Extensions.Logging;
 using Moq;
 using SmallEarthTech.AntPlus;
+using SmallEarthTech.AntPlus.DeviceProfiles;
 using SmallEarthTech.AntPlus.DeviceProfiles.AssetTracker;
 using SmallEarthTech.AntRadioInterface;
 using System.Threading;
@@ -121,5 +122,22 @@ namespace AntPlus.UnitTests
             Assert.IsTrue(offline == true);
             Assert.IsTrue(antDevice.Object.Offline == true);
         }
+
+        [TestMethod]
+        [DataRow((uint)0x0FFF0001, (uint)0x00000001)]
+        public void Test_ToJSON(uint channelId, uint expectedDeviceNumber)
+        {
+            // Arrange
+            ChannelId cid = new((uint)channelId);
+            string expectedString = "{\"ChannelCount\":8192,\"DataPages\":[],\"ChannelId\":{\"Id\":268369921,\"DeviceType\":127,\"DeviceNumber\":1,\"IsPairingBitSet\":true,\"TransmissionType\":3,\"AreGlobalDataPagesUsed\":true},\"Offline\":false,\"AntDeviceType\":\"UnknownDevice\"}";
+            Mock<ILogger<UnknownDevice>> mockUnknownDeviceLogger = mockRepository.Create<ILogger<UnknownDevice>>(MockBehavior.Loose);
+            UnknownDevice mockDevice = new(cid, mockAntChannel.Object, mockUnknownDeviceLogger.Object, (int)500); // Must be an actual device, because you can't serialize mocks
+                                                                                                                  // Act
+            string jsonString = mockDevice.ToJSON();
+            // Assert
+            Assert.AreEqual(expectedString, jsonString);
+        }
+
+
     }
 }

--- a/AntPlus/AntDevice.cs
+++ b/AntPlus/AntDevice.cs
@@ -3,7 +3,10 @@ using Microsoft.Extensions.Logging;
 using SmallEarthTech.AntPlus.DeviceProfiles;
 using SmallEarthTech.AntRadioInterface;
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Reflection;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -122,6 +125,22 @@ namespace SmallEarthTech.AntPlus
         public override string ToString()
         {
             return GetType().Name;
+        }
+
+        /// <summary>
+        /// Extracts the properties of the AntDevice and returns it as a JSON string.
+        /// </summary>
+        /// <returns>A JSON string representing the AntDevice</returns>
+        public string ToJSON()
+        {
+            Dictionary<string, object> extractedValues = new Dictionary<string, object>();
+            foreach (PropertyInfo propertyInfo in this.GetType().GetProperties())
+            {
+                if (propertyInfo.Name == "DeviceImageStream") { continue; } //Can't serialize a stream
+                extractedValues[propertyInfo.Name] = propertyInfo.GetValue(this, null);
+            }
+            extractedValues["AntDeviceType"] = this.GetType().Name;
+            return JsonSerializer.Serialize(extractedValues);
         }
 
         /// <summary>Requests the data page.</summary>

--- a/AntPlus/AntPlus.csproj
+++ b/AntPlus/AntPlus.csproj
@@ -91,6 +91,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
+    <PackageReference Include="System.Text.Json" Version="9.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Hi Stephen! 

Thank you so much for the AntPlus library. I'm attempting to use this library to feed my Power Meter and Stationary Bike Trainer Ant+ data to a Godot game. I was able wrap the Ant+ messgaes in an HTTP RESTful server. I think I could have adapted the gRPC interface but Godot has native HTTPRequest support and that is more convenient at the moment. 

To make the HTTP API code more convenient for myself I'd like to add this `ToJSON` method which extracts the current state of the AntDevice. I would like to eventually add my HTTP API to the /Examples folder, but for now I'm keeping it within my other project until it's more fleshed out.

I'm not sure if the test will be flaky, as it's a string to JSON and I'm unsure if the order is guaranteed. I had to use an concrete class for the test because reflection doesn't like the Mocks. 

Cheers!