### PR TITLE
47 handle ant radio device error

### DIFF
--- a/AntPlus.Extensions.Hosting/AntCollection.cs
+++ b/AntPlus.Extensions.Hosting/AntCollection.cs
@@ -91,6 +91,20 @@ namespace SmallEarthTech.AntPlus.Extensions.Hosting
                     e.ChannelNumber,
                     (MessageId)e.ResponseId,
                     e.Payload != null ? BitConverter.ToString(e.Payload) : "Null");
+
+                // if the ant response payload is not null and the second byte is 0x01 and the third byte is 0x07 then open Rx scan mode
+                if (e.Payload != null && e.Payload.Length > 2 && e.Payload[1] == 0x01 && e.Payload[2] == 0x07)
+                {
+                    // _antRadio is an IAntControl interface
+                    if (_antRadio is IAntControl antControl)
+                    {
+                        _ = antControl.OpenRxScanMode();
+                    }
+                    else
+                    {
+                        // TODO: Log error
+                    }
+                }
             }
         }
 

--- a/AntPlus.Extensions.Hosting/Hosting.csproj
+++ b/AntPlus.Extensions.Hosting/Hosting.csproj
@@ -16,7 +16,9 @@
 	<EmbedUntrackedSources>true</EmbedUntrackedSources>
 	<PackageIcon>PackageLogo.png</PackageIcon>
 	<PackageReadmeFile>readme.md</PackageReadmeFile>
-	<PackageReleaseNotes>Updated logging ANT+ logging extensions.</PackageReleaseNotes>
+	<PackageReleaseNotes>
+        1. Updated ANT+ logging with ANT+ logging extensions. 2. The scanning channel is re-opened if a close RF event is received.
+    </PackageReleaseNotes>
 	<PackageLicenseExpression>MIT</PackageLicenseExpression>
 	<IncludeSymbols>True</IncludeSymbols>
 	<SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/AntPlus.UnitTests/CommonDataPagesTests.cs
+++ b/AntPlus.UnitTests/CommonDataPagesTests.cs
@@ -16,6 +16,7 @@ namespace AntPlus.UnitTests
         public CommonDataPagesTests()
         {
             _mockLogger = new Mock<ILogger>();
+            _mockLogger.Setup(l => l.IsEnabled(It.IsAny<LogLevel>())).Returns(true);
             _commonDataPages = new(_mockLogger.Object);
         }
 
@@ -174,10 +175,10 @@ namespace AntPlus.UnitTests
             // Assert
             _mockLogger.Verify(
                 x => x.Log(
-                    LogLevel.Error,
+                    LogLevel.Warning,
                     It.IsAny<EventId>(),
-                    It.Is<It.IsAnyType>((v, t) => v.ToString().Contains("Invalid subfield data page")),
-                    It.Is<ArgumentOutOfRangeException>(ex => ex.Message.Contains("Invalid subpage")),
+                    It.Is<It.IsAnyType>((v, t) => v.ToString().Contains("is not defined in SubPage")),
+                    null,
                     It.IsAny<Func<It.IsAnyType, Exception, string>>()),
                 Times.Once);
         }
@@ -211,7 +212,7 @@ namespace AntPlus.UnitTests
                 x => x.Log(
                     LogLevel.Warning,
                     It.IsAny<EventId>(),
-                    It.Is<It.IsAnyType>((v, t) => v.ToString().Contains("Paired devices data page not implemented")),
+                    It.Is<It.IsAnyType>((v, t) => v.ToString().Contains("Ignoring page type PairedDevices")),
                     null,
                     It.IsAny<Func<It.IsAnyType, Exception, string>>()),
                 Times.Once);

--- a/AntPlus.UnitTests/DeviceProfiles/BicyclePower/CrankTorqueFrequencySensorTests.cs
+++ b/AntPlus.UnitTests/DeviceProfiles/BicyclePower/CrankTorqueFrequencySensorTests.cs
@@ -135,11 +135,11 @@ namespace AntPlus.UnitTests.DeviceProfiles.BicyclePowerTests
         }
 
         [Theory]
-        [InlineData(new byte[] { 0x01, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x11, 0x22 }, 3001)]
-        [InlineData(new byte[] { 0x01, 0x10, 0xFF, 0xFF, 0xFF, 0xFF, 0x11, 0x22 }, 3001)]
-        [InlineData(new byte[] { 0x01, 0x10, 0xAC, 0xFF, 0xFF, 0xFF, 0x11, 0x22 }, 3001)]
-        [InlineData(new byte[] { 0x02, 0x10, 0xAC, 0xFF, 0xFF, 0xFF, 0x11, 0x22 }, 3000)]
-        public void ParseUnknownCTFDefinedId_LogsWarning(byte[] dataPage, int eventId)
+        [InlineData(new byte[] { 0x01, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x11, 0x22 })]
+        [InlineData(new byte[] { 0x01, 0x10, 0xFF, 0xFF, 0xFF, 0xFF, 0x11, 0x22 })]
+        [InlineData(new byte[] { 0x01, 0x10, 0xAC, 0xFF, 0xFF, 0xFF, 0x11, 0x22 })]
+        [InlineData(new byte[] { 0x02, 0x10, 0xAC, 0xFF, 0xFF, 0xFF, 0x11, 0x22 })]
+        public void ParseUnknownCTFDefinedId_LogsWarning(byte[] dataPage)
         {
             // Arrange
 
@@ -150,7 +150,7 @@ namespace AntPlus.UnitTests.DeviceProfiles.BicyclePowerTests
             _mockLogger.Verify(
                 m => m.Log(
                     LogLevel.Warning,
-                    It.Is<EventId>(v => v.Id == eventId),
+                    It.IsAny<EventId>(),
                     It.Is<It.IsAnyType>((v, t) => v.ToString().Contains("Unknown data page")),
                     null,
                     It.IsAny<Func<It.IsAnyType, Exception, string>>()),
@@ -158,9 +158,9 @@ namespace AntPlus.UnitTests.DeviceProfiles.BicyclePowerTests
         }
 
         [Theory]
-        [InlineData(new byte[] { 0x01, 0x10, 0xAC, 0x02, 0xFF, 0xFF, 0xFF, 0xFF }, "Slope saved to flash.")]
-        [InlineData(new byte[] { 0x01, 0x10, 0xAC, 0x03, 0xFF, 0xFF, 0xFF, 0xFF }, "Serial number saved to flash.")]
-        public void ParseAcknowledgeMessage_LogsInformation(byte[] dataPage, string message)
+        [InlineData(new byte[] { 0x01, 0x10, 0xAC, 0x02, 0xFF, 0xFF, 0xFF, 0xFF }, "Data page type Slope")]
+        [InlineData(new byte[] { 0x01, 0x10, 0xAC, 0x03, 0xFF, 0xFF, 0xFF, 0xFF }, "Data page type SerialNumber")]
+        public void ParseAcknowledgeMessage_LogsDebugMessage(byte[] dataPage, string message)
         {
             // Arrange
             // Act
@@ -168,7 +168,7 @@ namespace AntPlus.UnitTests.DeviceProfiles.BicyclePowerTests
             // Assert
             _mockLogger.Verify(
                 m => m.Log(
-                    LogLevel.Information,
+                    LogLevel.Debug,
                     It.IsAny<EventId>(),
                     It.Is<It.IsAnyType>((v, t) => v.ToString().Contains(message)),
                     null,

--- a/AntPlus.UnitTests/SendMessageChannelTests.cs
+++ b/AntPlus.UnitTests/SendMessageChannelTests.cs
@@ -80,7 +80,7 @@ namespace AntPlus.UnitTests
         public async Task SendExtAcknowledgedDataAsync_InvokesMethodMultipleTimesAndReturnsPass()
         {
             var channelId = new ChannelId(0);
-            var data = Array.Empty<byte>();
+            var data = new byte[] { 0, 1, 2, 3, 4, 5, 6, 7 };
             var messagingReturnCode = MessagingReturnCode.Pass;
 
             _mockChannel.Setup(c => c.SendExtAcknowledgedDataAsync(channelId, data, It.IsAny<uint>()))
@@ -114,7 +114,7 @@ namespace AntPlus.UnitTests
         public async Task SendExtAcknowledgedDataAsync_InvokesMethodAndReturnsTimeout()
         {
             var channelId = new ChannelId(0);
-            var data = Array.Empty<byte>();
+            var data = new byte[] { 0, 1, 2, 3, 4, 5, 6, 7 };
             var messagingReturnCode = MessagingReturnCode.Timeout;
             _mockChannel.Setup(c => c.SendExtAcknowledgedDataAsync(channelId, data, It.IsAny<uint>()))
                         .ReturnsAsync(messagingReturnCode);

--- a/AntPlus/AntDeviceCollection.cs
+++ b/AntPlus/AntDeviceCollection.cs
@@ -35,7 +35,7 @@ namespace SmallEarthTech.AntPlus
         /// <code>BindingOperations.EnableCollectionSynchronization(App.AntDevices, App.AntDevices.CollectionLock);</code>
         /// This ensures changes to the collection are thread safe and marshalled on the UI thread.
         /// </remarks>
-        public object CollectionLock = new object();
+        public object CollectionLock = new();
 
         private readonly IAntRadio _antRadio;
         private readonly ILoggerFactory _loggerFactory;
@@ -77,27 +77,59 @@ namespace SmallEarthTech.AntPlus
             _channels[0].ChannelResponse += MessageHandler;
         }
 
-        private void MessageHandler(object sender, AntResponse e)
+        private void MessageHandler(object? sender, AntResponse e)
         {
             _logger.LogAntResponse(LogLevel.Trace, e);
-            if (e.ChannelId != null && e.Payload != null)
-            {
-                // see if the device is in the collection
-                AntDevice device = this.FirstOrDefault(ant => ant.ChannelId.Id == e.ChannelId.Id);
 
-                // create the device if not in the collection
-                if (device == null)
-                {
-                    // create the device and add it to the collection
-                    device = CreateAntDevice(e.ChannelId, e.Payload);
-                    Add(device);
-                    device.DeviceWentOffline += DeviceOffline;
-                }
-                device.Parse(e.Payload);    // dispatch the message to the device for processing
-            }
-            else
+            // check for a valid payload
+            if (e.Payload == null || e.Payload.Length < 3)
             {
                 _logger.LogUnhandledAntResponse(e);
+                return;
+            }
+
+            // switch on the response id
+            switch (e.ResponseId)
+            {
+                case MessageId.ChannelEventOrResponse:
+                    // check for a RF event on channel 0, channel closed event
+                    if (e.Payload[0] != 0 || e.Payload[1] != 1 || (EventMsgId)e.Payload[2] != EventMsgId.ChannelClosed)
+                    {
+                        _logger.LogUnhandledAntResponse(e);
+                        return;
+                    }
+
+                    // re-open the channel in scan mode
+                    _ = ((IAntControl)_antRadio).OpenRxScanMode();
+                    break;
+                case MessageId.BroadcastData:
+                case MessageId.ExtBroadcastData:
+                    // check for a valid channel id and payload length
+                    if (e.ChannelId == null || e.Payload.Length != 8)
+                    {
+                        _logger.LogUnhandledAntResponse(e);
+                        return;
+                    }
+
+                    // see if the device is in the collection
+                    AntDevice device = this.FirstOrDefault(ant => ant.ChannelId.Id == e.ChannelId!.Id);
+
+                    // create the device if not in the collection
+                    if (device == null)
+                    {
+                        // create an ANT device from the AntResponse parameter
+                        device = CreateAntDevice(e);
+
+                        Add(device);
+                        device.DeviceWentOffline += DeviceOffline;
+                    }
+
+                    // dispatch the message to the device
+                    device.Parse(e.Payload!);
+                    break;
+                default:
+                    _logger.LogUnhandledAntResponse(e);
+                    break;
             }
         }
 
@@ -131,21 +163,21 @@ namespace SmallEarthTech.AntPlus
             }
         }
 
-        private AntDevice CreateAntDevice(ChannelId channelId, byte[] dataPage)
+        private AntDevice CreateAntDevice(AntResponse response)
         {
-            return channelId.DeviceType switch
+            return response.ChannelId!.DeviceType switch
             {
-                BicyclePower.DeviceClass => BicyclePower.GetBicyclePowerSensor(dataPage, channelId, _sendMessageChannel!, _loggerFactory, _timeout),
-                BikeSpeedSensor.DeviceClass => new BikeSpeedSensor(channelId, _sendMessageChannel!, _loggerFactory.CreateLogger<BikeSpeedSensor>(), _timeout),
-                BikeCadenceSensor.DeviceClass => new BikeCadenceSensor(channelId, _sendMessageChannel!, _loggerFactory.CreateLogger<BikeCadenceSensor>(), _timeout),
-                CombinedSpeedAndCadenceSensor.DeviceClass => new CombinedSpeedAndCadenceSensor(channelId, _sendMessageChannel!, _loggerFactory.CreateLogger<CombinedSpeedAndCadenceSensor>(), _timeout),
-                FitnessEquipment.DeviceClass => FitnessEquipment.GetFitnessEquipment(dataPage, channelId, _sendMessageChannel!, _loggerFactory, _timeout) ?? (AntDevice)new UnknownDevice(channelId, _sendMessageChannel!, _loggerFactory.CreateLogger<UnknownDevice>(), _timeout),
-                MuscleOxygen.DeviceClass => new MuscleOxygen(channelId, _sendMessageChannel!, _loggerFactory.CreateLogger<MuscleOxygen>(), _timeout),
-                Geocache.DeviceClass => new Geocache(channelId, _sendMessageChannel!, _loggerFactory.CreateLogger<Geocache>(), _timeout),
-                Tracker.DeviceClass => new Tracker(channelId, _sendMessageChannel!, _loggerFactory.CreateLogger<Tracker>(), _timeout),
-                StrideBasedSpeedAndDistance.DeviceClass => new StrideBasedSpeedAndDistance(channelId, _sendMessageChannel!, _loggerFactory.CreateLogger<StrideBasedSpeedAndDistance>(), _timeout),
-                HeartRate.DeviceClass => new HeartRate(channelId, _sendMessageChannel!, _loggerFactory.CreateLogger<HeartRate>(), _timeout),
-                _ => new UnknownDevice(channelId, _sendMessageChannel!, _loggerFactory.CreateLogger<UnknownDevice>(), _timeout),
+                BicyclePower.DeviceClass => BicyclePower.GetBicyclePowerSensor(response.Payload!, response.ChannelId, _sendMessageChannel!, _loggerFactory, _timeout),
+                BikeSpeedSensor.DeviceClass => new BikeSpeedSensor(response.ChannelId, _sendMessageChannel!, _loggerFactory.CreateLogger<BikeSpeedSensor>(), _timeout),
+                BikeCadenceSensor.DeviceClass => new BikeCadenceSensor(response.ChannelId, _sendMessageChannel!, _loggerFactory.CreateLogger<BikeCadenceSensor>(), _timeout),
+                CombinedSpeedAndCadenceSensor.DeviceClass => new CombinedSpeedAndCadenceSensor(response.ChannelId, _sendMessageChannel!, _loggerFactory.CreateLogger<CombinedSpeedAndCadenceSensor>(), _timeout),
+                FitnessEquipment.DeviceClass => FitnessEquipment.GetFitnessEquipment(response.Payload!, response.ChannelId, _sendMessageChannel!, _loggerFactory, _timeout) ?? (AntDevice)new UnknownDevice(response.ChannelId, _sendMessageChannel!, _loggerFactory.CreateLogger<UnknownDevice>(), _timeout),
+                MuscleOxygen.DeviceClass => new MuscleOxygen(response.ChannelId, _sendMessageChannel!, _loggerFactory.CreateLogger<MuscleOxygen>(), _timeout),
+                Geocache.DeviceClass => new Geocache(response.ChannelId, _sendMessageChannel!, _loggerFactory.CreateLogger<Geocache>(), _timeout),
+                Tracker.DeviceClass => new Tracker(response.ChannelId, _sendMessageChannel!, _loggerFactory.CreateLogger<Tracker>(), _timeout),
+                StrideBasedSpeedAndDistance.DeviceClass => new StrideBasedSpeedAndDistance(response.ChannelId, _sendMessageChannel!, _loggerFactory.CreateLogger<StrideBasedSpeedAndDistance>(), _timeout),
+                HeartRate.DeviceClass => new HeartRate(response.ChannelId, _sendMessageChannel!, _loggerFactory.CreateLogger<HeartRate>(), _timeout),
+                _ => new UnknownDevice(response.ChannelId, _sendMessageChannel!, _loggerFactory.CreateLogger<UnknownDevice>(), _timeout),
             };
         }
     }

--- a/AntPlus/AntPlus.csproj
+++ b/AntPlus/AntPlus.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	<AssemblyVersion>5.0.1.0</AssemblyVersion>
+	<AssemblyVersion>5.1.0.0</AssemblyVersion>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <RootNamespace>SmallEarthTech.$(MSBuildProjectName.Replace(" ", "_"))</RootNamespace>
@@ -24,7 +24,9 @@
 	<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 	<PackageIcon>PackageLogo.png</PackageIcon>
 	<PackageReadmeFile>readme.md</PackageReadmeFile>
-	<PackageReleaseNotes>Bugfix: Issue #39. Clears msssage in ANT radio hardware when SendExtAcknowledgedDataAsync timesout.</PackageReleaseNotes>
+	<PackageReleaseNotes>
+        1. Updated ANT+ logging with ANT+ logging extensions. 2. The scanning channel is re-opened if a close RF event is received.
+    </PackageReleaseNotes>
   </PropertyGroup>
 
     <PropertyGroup>

--- a/AntPlus/CommonDataPages.cs
+++ b/AntPlus/CommonDataPages.cs
@@ -297,8 +297,11 @@ namespace SmallEarthTech.AntPlus
             /// <summary>Gets the computed data field 2. Returns NaN if this is not a valid subpage.</summary>
             public double ComputedDataField2 { get; }
 
+            private readonly byte[] dp;
+
             internal SubfieldDataPage(byte[] dataPage, ILogger logger)
             {
+                dp = dataPage;
                 Subpage1 = (SubPage)dataPage[2];
                 Subpage2 = (SubPage)dataPage[3];
                 ComputedDataField1 = double.NaN;
@@ -339,7 +342,7 @@ namespace SmallEarthTech.AntPlus
                     case SubPage.Invalid:
                         break;
                     default:
-                        logger.LogUnknownDataPage<SubPage>((byte)page, Array.Empty<byte>());
+                        logger.LogUnknownDataPage<SubPage>((byte)page, dp);
                         break;
                 }
                 return retVal;

--- a/Documentation/Content/VersionHistory/AntPlus/v5.1.0.0.aml
+++ b/Documentation/Content/VersionHistory/AntPlus/v5.1.0.0.aml
@@ -33,9 +33,16 @@
 						<linkText>Issue #45.</linkText>
 						<linkUri>https://github.com/StephenHidem/AntPlus/issues/45</linkUri>
 					</externalLink>
-					Logger extensions for ANT+. These extensions enhance the logging experience with a consistent format and parameter conversions.
+					Added logger extensions for ANT+. These extensions enhance the logging experience with a consistent format and parameter conversions.
 				</para>
-      </content>
+				<para>
+					<externalLink>
+						<linkText>Issue #47.</linkText>
+						<linkUri>https://github.com/StephenHidem/AntPlus/issues/47</linkUri>
+					</externalLink>
+					The scanning channel is re-opened if a close channel RF event is received.
+				</para>
+			</content>
       <!-- If a section contains a sections element, its content creates
            sub-sections.  These are not collapsible.
       <sections>

--- a/Documentation/Content/VersionHistory/HostingExtensions/v1.2.0.0.aml
+++ b/Documentation/Content/VersionHistory/HostingExtensions/v1.2.0.0.aml
@@ -33,9 +33,16 @@
 						<linkText>Issue #45.</linkText>
 						<linkUri>https://github.com/StephenHidem/AntPlus/issues/45</linkUri>
 					</externalLink>
-					Using logger extensions from ANT+ library to enhance logging experience.
+					Uses logger extensions from ANT+ library to enhance logging experience.
 				</para>
-      </content>
+				<para>
+					<externalLink>
+						<linkText>Issue #47.</linkText>
+						<linkUri>https://github.com/StephenHidem/AntPlus/issues/47</linkUri>
+					</externalLink>
+					The scanning channel is re-opened if a close channel RF event is received.
+				</para>
+			</content>
       <!-- If a section contains a sections element, its content creates
            sub-sections.  These are not collapsible.
       <sections>

--- a/Extensions/Hosting/Hosting.UnitTests/SendMessageChannelTests.cs
+++ b/Extensions/Hosting/Hosting.UnitTests/SendMessageChannelTests.cs
@@ -76,7 +76,7 @@ namespace Hosting.UnitTests
         public async Task SendExtAcknowledgedDataAsync_InvokesMethodMultipleTimesAndReturnsPass()
         {
             var channelId = new ChannelId(0);
-            var data = Array.Empty<byte>();
+            var data = new byte[] { 0, 1, 2, 3, 4, 5, 6, 7 };
             var messagingReturnCode = MessagingReturnCode.Pass;
 
             _mockChannel.Setup(c => c.SendExtAcknowledgedDataAsync(channelId, data, It.IsAny<uint>()))
@@ -110,7 +110,7 @@ namespace Hosting.UnitTests
         public async Task SendExtAcknowledgedDataAsync_InvokesMethodAndReturnsTimeout()
         {
             var channelId = new ChannelId(0);
-            var data = Array.Empty<byte>();
+            var data = new byte[] { 0, 1, 2, 3, 4, 5, 6, 7 };
             var messagingReturnCode = MessagingReturnCode.Timeout;
             _mockChannel.Setup(c => c.SendExtAcknowledgedDataAsync(channelId, data, It.IsAny<uint>()))
                         .ReturnsAsync(messagingReturnCode);


### PR DESCRIPTION
Re-open scanning channel fixes issue. Closes #47.
- Bumped version numbers of affected assemblies.
- Updated release notes.
- Updated documentation.
- Fixed unit tests.
- Fixed bug parsing sub-field data in common data pages.