### PR TITLE
Add Legacy Stationary Bike

### DIFF
--- a/AntPlus.UnitTests/DeviceProfiles/FitnessEquipment/FitnessEquipmentTests.cs
+++ b/AntPlus.UnitTests/DeviceProfiles/FitnessEquipment/FitnessEquipmentTests.cs
@@ -47,10 +47,48 @@ namespace AntPlus.UnitTests.DeviceProfiles.FitnessEquipment
         }
 
         [Theory]
+        [InlineData(FitnessEquipmentType.Treadmill, DataPage.GeneralFEData)]
+        [InlineData(FitnessEquipmentType.Treadmill, DataPage.GeneralMetabolicData)]
+        [InlineData(FitnessEquipmentType.Treadmill, DataPage.GeneralSettings)]
+        [InlineData(FitnessEquipmentType.Treadmill, DataPage.TreadmillData)]
+        [InlineData(FitnessEquipmentType.Elliptical, DataPage.EllipticalData)]
+        [InlineData(FitnessEquipmentType.Rower, DataPage.RowerData)]
+        [InlineData(FitnessEquipmentType.Climber, DataPage.ClimberData)]
+        [InlineData(FitnessEquipmentType.StationaryBike, DataPage.StationaryBikeData)]
+        [InlineData(FitnessEquipmentType.NordicSkier, DataPage.NordicSkierData)]
+        [InlineData(FitnessEquipmentType.TrainerStationaryBike, DataPage.TrainerStationaryBikeData)]
+        public void Parse_DataPage_LapToggledEventRaised(FitnessEquipmentType equipmentType, DataPage page)
+        {
+            // Arrange
+            var fitnessEquipment = CreateFitnessEquipment(equipmentType);
+            byte[] dataPage = [(byte)page, 0, 0, 0, 0, 0, 0, 0x80];
+            bool eventRaised = false;
+            bool lowHighToggle = false;
+            bool highLowToggle = false;
+            fitnessEquipment.LapToggled += (s, e) => eventRaised = true;
+
+            // Act
+            fitnessEquipment.Parse(
+                dataPage);
+            lowHighToggle = eventRaised;
+
+            eventRaised = false;
+            dataPage[7] = 0x00; // Toggle back to low
+            fitnessEquipment.Parse(
+                dataPage);
+            highLowToggle = eventRaised;
+
+            // Assert
+            Assert.True(lowHighToggle);
+            Assert.True(highLowToggle);
+        }
+
+        [Theory]
         [InlineData(FitnessEquipmentType.Treadmill)]
         [InlineData(FitnessEquipmentType.Elliptical)]
         [InlineData(FitnessEquipmentType.Rower)]
         [InlineData(FitnessEquipmentType.Climber)]
+        [InlineData(FitnessEquipmentType.StationaryBike)]
         [InlineData(FitnessEquipmentType.NordicSkier)]
         [InlineData(FitnessEquipmentType.TrainerStationaryBike)]
         public void GetEquipment_GeneralDataPage_ExpectedEquipment(FitnessEquipmentType equipmentType)
@@ -73,6 +111,9 @@ namespace AntPlus.UnitTests.DeviceProfiles.FitnessEquipment
                 case FitnessEquipmentType.Climber:
                     Assert.IsType<Climber>(fitnessEquipment);
                     break;
+                case FitnessEquipmentType.StationaryBike:
+                    Assert.IsType<StationaryBike>(fitnessEquipment);
+                    break;
                 case FitnessEquipmentType.NordicSkier:
                     Assert.IsType<NordicSkier>(fitnessEquipment);
                     break;
@@ -90,6 +131,7 @@ namespace AntPlus.UnitTests.DeviceProfiles.FitnessEquipment
         [InlineData(DataPage.EllipticalData, FitnessEquipmentType.Elliptical)]
         [InlineData(DataPage.RowerData, FitnessEquipmentType.Rower)]
         [InlineData(DataPage.ClimberData, FitnessEquipmentType.Climber)]
+        [InlineData(DataPage.StationaryBikeData, FitnessEquipmentType.StationaryBike)]
         [InlineData(DataPage.NordicSkierData, FitnessEquipmentType.NordicSkier)]
         [InlineData(DataPage.TrainerStationaryBikeData, FitnessEquipmentType.TrainerStationaryBike)]
         [InlineData(DataPage.TrainerTorqueData, FitnessEquipmentType.TrainerStationaryBike)]
@@ -115,6 +157,9 @@ namespace AntPlus.UnitTests.DeviceProfiles.FitnessEquipment
                     break;
                 case FitnessEquipmentType.Climber:
                     Assert.IsType<Climber>(fitnessEquipment);
+                    break;
+                case FitnessEquipmentType.StationaryBike:
+                    Assert.IsType<StationaryBike>(fitnessEquipment);
                     break;
                 case FitnessEquipmentType.NordicSkier:
                     Assert.IsType<NordicSkier>(fitnessEquipment);

--- a/AntPlus.UnitTests/DeviceProfiles/FitnessEquipment/StationaryBikeTests.cs
+++ b/AntPlus.UnitTests/DeviceProfiles/FitnessEquipment/StationaryBikeTests.cs
@@ -1,0 +1,62 @@
+﻿using Microsoft.Extensions.Logging;
+using Moq;
+using SmallEarthTech.AntPlus.DeviceProfiles.FitnessEquipment;
+using SmallEarthTech.AntRadioInterface;
+using Xunit;
+
+namespace AntPlus.UnitTests.DeviceProfiles.FitnessEquipment
+{
+    public class StationaryBikeTests
+    {
+        private readonly StationaryBike _stationaryBike;
+
+        public StationaryBikeTests()
+        {
+            _stationaryBike = new(new ChannelId(0), Mock.Of<IAntChannel>(), Mock.Of<ILogger<StationaryBike>>(), It.IsAny<int>());
+        }
+
+        [Fact]
+        public void Parse_InstantaneousCadenceAndPower_Matches()
+        {
+            // Arrange
+            byte[] dataPage = [0x15, 0xFF, 0xFF, 0xFF, 60, 150, 0, 0];
+
+            // Act
+            _stationaryBike.Parse(dataPage);
+
+            // Assert
+            Assert.Equal(60, _stationaryBike.Cadence);
+            Assert.Equal(150, _stationaryBike.InstantaneousPower);
+        }
+
+        [Fact]
+        public void Parse_PowerHighValue_Correct()
+        {
+            // Arrange - 274W = 0x0112
+            byte[] dataPage = [0x15, 0xFF, 0xFF, 0xFF, 87, 0x12, 0x01, 0];
+
+            // Act
+            _stationaryBike.Parse(dataPage);
+
+            // Assert
+            Assert.Equal(87, _stationaryBike.Cadence);
+            Assert.Equal(274, _stationaryBike.InstantaneousPower);
+        }
+
+        [Fact]
+        public void Parse_CommonDataPage_Handled()
+        {
+            // Arrange - common page 0x50 (Manufacturer Info)
+            byte[] dataPage = [0x50, 0xFF, 0xFF, 16, 32, 0, 100, 0];
+
+            // Act & Assert - should not throw
+            _stationaryBike.Parse(dataPage);
+        }
+
+        [Fact]
+        public void ToString_ReturnsExpected()
+        {
+            Assert.Equal("Stationary Bike", _stationaryBike.ToString());
+        }
+    }
+}

--- a/AntPlus/AntPlus.csproj
+++ b/AntPlus/AntPlus.csproj
@@ -5,7 +5,7 @@
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <RootNamespace>SmallEarthTech.$(MSBuildProjectName.Replace(" ", "_"))</RootNamespace>
     <PackageId>SmallEarthTech.$(AssemblyName)</PackageId>
-    <VersionPrefix>6.0.4</VersionPrefix>
+    <VersionPrefix>6.1.0</VersionPrefix>
     <Title>ANT+ Class Library</Title>
     <PackageProjectUrl>https://stephenhidem.github.io/AntPlus</PackageProjectUrl>
     <Authors>Stephen Hidem</Authors>
@@ -23,16 +23,19 @@
 	<PackageIcon>PackageLogo.png</PackageIcon>
 	<PackageReadmeFile>readme.md</PackageReadmeFile>
 	<PackageReleaseNotes>
-		1. Updated NuGet dependencies.
+		1. New device profile: Legacy Stationary Bike added to Fitness Equipment category.
+		2. Refactor: HandleFEState handles lap toggle.
+		3. Bug fix: Treadmill now correctly handles fitness equipment state.
+		4. Updated NuGet dependencies.
 	</PackageReleaseNotes>
 	<Configurations>Debug;Release</Configurations>
   </PropertyGroup>
 
     <PropertyGroup>
-       <LangVersion>9.0</LangVersion>
-       <Nullable>enable</Nullable>
-       <PackageLicenseFile>OSMFEULA.txt</PackageLicenseFile>
-       <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
+        <LangVersion>9.0</LangVersion>
+        <Nullable>enable</Nullable>
+        <PackageLicenseFile>OSMFEULA.txt</PackageLicenseFile>
+        <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
     </PropertyGroup>
 
   <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">

--- a/AntPlus/DeviceProfiles/FitnessEquipment/FitnessEquipment.cs
+++ b/AntPlus/DeviceProfiles/FitnessEquipment/FitnessEquipment.cs
@@ -49,6 +49,8 @@ namespace SmallEarthTech.AntPlus.DeviceProfiles.FitnessEquipment
             TreadmillData = 0x13,
             /// <summary>Elliptical data page</summary>
             EllipticalData = 0x14,
+            /// <summary> Legacy stationary bike dAta page</summary>
+            StationaryBikeData = 0x15,
             /// <summary>Rower data page</summary>
             RowerData = 0x16,
             /// <summary>Climber data page</summary>
@@ -82,6 +84,8 @@ namespace SmallEarthTech.AntPlus.DeviceProfiles.FitnessEquipment
             Treadmill = 0x13,
             /// <summary>Elliptical</summary>
             Elliptical = 0x14,
+            /// <summary>Legacy stationary bike</summary>
+            StationaryBike = 0x15,
             /// <summary>Rower</summary>
             Rower = 0x16,
             /// <summary>Climber</summary>
@@ -328,13 +332,6 @@ namespace SmallEarthTech.AntPlus.DeviceProfiles.FitnessEquipment
                 case DataPage.GeneralFEData:
                     HandleFEState(dataPage);
                     GeneralData.Parse(dataPage);
-
-                    // check for lap toggle
-                    if (lapToggleState != ((dataPage[7] & 0x80) == 0x80))
-                    {
-                        lapToggleState = (dataPage[7] & 0x80) == 0x80;
-                        LapToggled?.Invoke(this, EventArgs.Empty);
-                    }
                     break;
                 case DataPage.GeneralSettings:
                     HandleFEState(dataPage);
@@ -344,7 +341,7 @@ namespace SmallEarthTech.AntPlus.DeviceProfiles.FitnessEquipment
                     HandleFEState(dataPage);
                     GeneralMetabolic.Parse(dataPage);
                     break;
-                // handle specific FE pages
+                // handle on demand pages
                 case DataPage.FECapabilities:
                     MaxTrainerResistance = BitConverter.ToUInt16(dataPage, 5);
                     TrainingModes = (SupportedTrainingModes)dataPage[7];
@@ -355,10 +352,17 @@ namespace SmallEarthTech.AntPlus.DeviceProfiles.FitnessEquipment
             }
         }
 
-        /// <summary>Handles the state of the fitness equipment.</summary>
+        /// <summary>Handles the state of the fitness equipment including the lap toggle.</summary>
         /// <param name="dataPage">The data page being parsed.</param>
         protected void HandleFEState(byte[] dataPage)
         {
+            // check for lap toggle
+            if (lapToggleState != ((dataPage[7] & 0x80) == 0x80))
+            {
+                lapToggleState = (dataPage[7] & 0x80) == 0x80;
+                LapToggled?.Invoke(this, EventArgs.Empty);
+            }
+
             var st = (dataPage[7] & 0x70) >> 4;
             // check for valid state
             if (Enum.IsDefined(typeof(FEState), st))
@@ -478,6 +482,8 @@ namespace SmallEarthTech.AntPlus.DeviceProfiles.FitnessEquipment
                             return new Treadmill(channelId, antChannel, loggerFactory.CreateLogger<Treadmill>(), timeout);
                         case FitnessEquipmentType.Elliptical:
                             return new Elliptical(channelId, antChannel, loggerFactory.CreateLogger<Elliptical>(), timeout);
+                        case FitnessEquipmentType.StationaryBike:
+                            return new StationaryBike(channelId, antChannel, loggerFactory.CreateLogger<StationaryBike>(), timeout);
                         case FitnessEquipmentType.Rower:
                             return new Rower(channelId, antChannel, loggerFactory.CreateLogger<Rower>(), timeout);
                         case FitnessEquipmentType.Climber:
@@ -495,6 +501,8 @@ namespace SmallEarthTech.AntPlus.DeviceProfiles.FitnessEquipment
                     return new Treadmill(channelId, antChannel, loggerFactory.CreateLogger<Treadmill>(), timeout);
                 case DataPage.EllipticalData:
                     return new Elliptical(channelId, antChannel, loggerFactory.CreateLogger<Elliptical>(), timeout);
+                case DataPage.StationaryBikeData:
+                    return new StationaryBike(channelId, antChannel, loggerFactory.CreateLogger<StationaryBike>(), timeout);
                 case DataPage.RowerData:
                     return new Rower(channelId, antChannel, loggerFactory.CreateLogger<Rower>(), timeout);
                 case DataPage.ClimberData:

--- a/AntPlus/DeviceProfiles/FitnessEquipment/StationaryBike.cs
+++ b/AntPlus/DeviceProfiles/FitnessEquipment/StationaryBike.cs
@@ -5,6 +5,9 @@ using System;
 
 namespace SmallEarthTech.AntPlus.DeviceProfiles.FitnessEquipment
 {
+    /// <summary>
+    /// This class supports the ANT+ Legacy Stationary Bike device profile. It extends the FitnessEquipment base class to provide specific properties and parsing logic for stationary bike data pages, including cadence and instantaneous power.
+    /// </summary>
     public partial class StationaryBike : FitnessEquipment
     {
         /// <summary>Gets the instantaneous pedaling cadence in revolutions per minute.</summary>

--- a/AntPlus/DeviceProfiles/FitnessEquipment/StationaryBike.cs
+++ b/AntPlus/DeviceProfiles/FitnessEquipment/StationaryBike.cs
@@ -1,0 +1,57 @@
+﻿using CommunityToolkit.Mvvm.ComponentModel;
+using Microsoft.Extensions.Logging;
+using SmallEarthTech.AntRadioInterface;
+using System;
+
+namespace SmallEarthTech.AntPlus.DeviceProfiles.FitnessEquipment
+{
+    public partial class StationaryBike : FitnessEquipment
+    {
+        /// <summary>Gets the instantaneous pedaling cadence in revolutions per minute.</summary>
+        /// <value>The instantaneous cadence.</value>
+        [ObservableProperty]
+        private byte cadence;
+        /// <summary>Gets the instantaneous power in watts.</summary>
+        /// <value>The instantaneous power.</value>
+        [ObservableProperty]
+        private int instantaneousPower;
+
+        /// <summary>Initializes a new instance of the <see cref="StationaryBike" /> class.</summary>
+        /// <inheritdoc cref="AntDevice(ChannelId, IAntChannel, ILogger, int)"/>
+        public StationaryBike(ChannelId channelId, IAntChannel antChannel, ILogger logger, int timeout) : base(channelId, antChannel, logger, timeout)
+        {
+        }
+
+        /// <summary>Initializes a new instance of the <see cref="StationaryBike" /> class.</summary>
+        /// <inheritdoc cref="AntDevice(ChannelId, IAntChannel, ILogger, TimeoutOptions?)"/>
+        public StationaryBike(ChannelId channelId, IAntChannel antChannel, ILogger logger, TimeoutOptions? timeoutOptions) : base(channelId, antChannel, logger, timeoutOptions)
+        {
+        }
+
+        /// <summary>
+        /// Parses the specified data page and updates the relevant properties.
+        /// </summary>
+        /// <remarks>If the data page represents stationary bike data, the method extracts cadence and
+        /// instantaneous power values. For other data page types, common data page parsing is delegated to the
+        /// CommonDataPages class. The method does not process the page if it has already been handled.</remarks>
+        /// <param name="dataPage">A byte array containing the data page to parse.</param>
+        override public void Parse(byte[] dataPage)
+        {
+            base.Parse(dataPage);
+            if (handledPage) return;
+
+            if ((DataPage)dataPage[0] == DataPage.StationaryBikeData)
+            {
+                Cadence = dataPage[4];
+                InstantaneousPower = BitConverter.ToInt16(dataPage, 5);
+            }
+            else
+            {
+                CommonDataPages.ParseCommonDataPage(dataPage);
+            }
+        }
+
+        /// <inheritdoc/>
+        public override string ToString() => "Stationary Bike";
+    }
+}

--- a/AntPlus/DeviceProfiles/FitnessEquipment/StationaryBike.cs
+++ b/AntPlus/DeviceProfiles/FitnessEquipment/StationaryBike.cs
@@ -8,11 +8,11 @@ namespace SmallEarthTech.AntPlus.DeviceProfiles.FitnessEquipment
     public partial class StationaryBike : FitnessEquipment
     {
         /// <summary>Gets the instantaneous pedaling cadence in revolutions per minute.</summary>
-        /// <value>The instantaneous cadence.</value>
+        /// <value>The instantaneous cadence. 255 (0xFF) indicates invalid.</value>
         [ObservableProperty]
         private byte cadence;
         /// <summary>Gets the instantaneous power in watts.</summary>
-        /// <value>The instantaneous power.</value>
+        /// <value>The instantaneous power. 65535 (0xFFFF) indicates invalid.</value>
         [ObservableProperty]
         private int instantaneousPower;
 
@@ -42,6 +42,7 @@ namespace SmallEarthTech.AntPlus.DeviceProfiles.FitnessEquipment
 
             if ((DataPage)dataPage[0] == DataPage.StationaryBikeData)
             {
+                HandleFEState(dataPage);
                 Cadence = dataPage[4];
                 InstantaneousPower = BitConverter.ToInt16(dataPage, 5);
             }

--- a/AntPlus/DeviceProfiles/FitnessEquipment/TrainerStationaryBike.cs
+++ b/AntPlus/DeviceProfiles/FitnessEquipment/TrainerStationaryBike.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 namespace SmallEarthTech.AntPlus.DeviceProfiles.FitnessEquipment
 {
     /// <summary>
-    /// This class supports the stationary bike fitness equipment type.
+    /// This class supports the trainer/stationary bike fitness equipment type.
     /// </summary>
     public partial class TrainerStationaryBike : FitnessEquipment
     {

--- a/AntPlus/DeviceProfiles/FitnessEquipment/Treadmill.cs
+++ b/AntPlus/DeviceProfiles/FitnessEquipment/Treadmill.cs
@@ -65,6 +65,7 @@ namespace SmallEarthTech.AntPlus.DeviceProfiles.FitnessEquipment
 
             if ((DataPage)dataPage[0] == DataPage.TreadmillData)
             {
+                HandleFEState(dataPage);
                 if (isFirstDataMessage)
                 {
                     prevNeg = dataPage[5];

--- a/Documentation/Content/VersionHistory/AntPlus/v6.1.0.0.aml
+++ b/Documentation/Content/VersionHistory/AntPlus/v6.1.0.0.aml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<topic id="c4caecfe-e2ea-4c87-b602-75d6b57aa70b" revisionNumber="1">
+<topic id="2b295d47-8d19-4efd-8ed5-775da9613fab" revisionNumber="1">
   <developerConceptualDocument
     xmlns="http://ddue.schemas.microsoft.com/authoring/2003/5"
     xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -17,107 +17,32 @@
            zero (0) to limit it to top-level sections only.  -->
       <!-- <autoOutline /> -->
 
-      <para>Version 1.0.0.0 was released on May 13, 2023.</para>
+      <para>Release Date: April 14, 2026</para>
     </introduction>
 
     <!-- Add one or more top-level section elements.  These are collapsible.
          If using <autoOutline />, add an address attribute to identify it
          and specify a title so that it can be jumped to with a hyperlink. -->
     <section address="Section1">
-			<content>
-				<list class="bullet">
-					<listItem>
-						<para>
-							<link xlink:href="b3754de5-1d8d-422e-9071-12d290d4b14d" />
-						</para>
-					</listItem>
-					<listItem>
-						<para>
-							<link xlink:href="607e34e9-cdf4-4f9a-85c6-78f830e1aff8" />
-						</para>
-					</listItem>
-					<listItem>
-						<para>
-							<link xlink:href="892f97e4-a593-403f-bcfe-1b546a86ed2d" />
-						</para>
-					</listItem>
-					<listItem>
-						<para>
-							<link xlink:href="988b09e9-af30-438d-ad2d-0b86a818f97d" />
-						</para>
-					</listItem>
-					<listItem>
-						<para>
-							<link xlink:href="5784e268-84d1-466a-aa3a-e0fb8085a4ff" />
-						</para>
-					</listItem>
-					<listItem>
-						<para>
-							<link xlink:href="44f85400-6285-4dbe-8f65-d28b68108fc1" />
-						</para>
-					</listItem>
-					<listItem>
-						<para>
-							<link xlink:href="10a23545-666c-497d-a851-14eb7ac619e8" />
-						</para>
-					</listItem>
-					<listItem>
-						<para>
-							<link xlink:href="73712ef4-127a-4e35-b2ef-dd212b42b2cc" />
-						</para>
-					</listItem>
-					<listItem>
-						<para>
-							<link xlink:href="42c82c98-5ad0-453d-a7ae-50ca9a9f19b6" />
-						</para>
-					</listItem>
-					<listItem>
-						<para>
-							<link xlink:href="feed7e23-c9c3-44df-804e-54b6bdab7962" />
-						</para>
-					</listItem>
-					<listItem>
-						<para>
-							<link xlink:href="f68a7258-6432-4d9f-8669-610681ea1f99" />
-						</para>
-					</listItem>
-					<listItem>
-						<para>
-							<link xlink:href="724ada0f-d2e9-49df-b466-96568945f5c9" />
-						</para>
-					</listItem>
-					<listItem>
-						<para>
-							<link xlink:href="d3c019fb-0c05-409e-9283-c72089d4df8c" />
-						</para>
-					</listItem>
-					<listItem>
-						<para>
-							<link xlink:href="e9279c3f-026c-438f-bf72-b85905f30e31" />
-						</para>
-					</listItem>
-					<listItem>
-						<para>
-							<link xlink:href="b747c524-6203-4a88-8d66-7ae0f14fbf2b" />
-						</para>
-					</listItem>
-					<listItem>
-					  <para>
-					    <link xlink:href="f78a2341-be7d-4efc-85de-bb79cf438b13" />
-					  </para>
-					</listItem>
-					<listItem>
-						<para>
-							<link xlink:href="96dd3305-46d4-42b2-bfa0-0ccf90028989" />
-						</para>
-					</listItem>
-					<listItem>
-						<para>
-							<link xlink:href="2b295d47-8d19-4efd-8ed5-775da9613fab" />
-						</para>
-					</listItem>
-				</list>
-      	</content>
+      <title>Changes</title>
+      <content>
+        <!-- Uncomment this to create a sub-section outline
+        <autoOutline /> -->
+		  <list class="bullet">
+			  <listItem>
+				  <para>New device profile: Legacy Stationary Bike added to Fitness Equipment category.</para>
+			  </listItem>
+			  <listItem>
+				  <para>Refactor: HandleFEState handles lap toggle.</para>
+			  </listItem>
+			  <listItem>
+				  <para>Bug fix: Treadmill now correctly handles fitness equipment state.</para>
+			  </listItem>
+			  <listItem>
+				  <para>Updated NuGet dependencies to latest version.</para>
+			  </listItem>
+		  </list>
+	  </content>
       <!-- If a section contains a sections element, its content creates
            sub-sections.  These are not collapsible.
       <sections>
@@ -137,8 +62,8 @@
     </section>
 
     <relatedTopics>
-			<link xlink:href="4a8ae1c2-5d9b-4e27-bd18-34b479401b65" />
-			<!-- One or more of the following:
+		<link xlink:href="c4caecfe-e2ea-4c87-b602-75d6b57aa70b" />
+		<!-- One or more of the following:
            - A local link
            - An external link
            - A code entity reference
@@ -160,7 +85,7 @@
       <link xlink:href="00e97994-e9e6-46e0-b420-5be86b2f8278">Some other topic</link>
 
       <externalLink>
-          <linkText>SHFB on GitHub</linkText>
+          <linkText>Sandcastle Help File Builder on GitHub</linkText>
           <linkAlternateText>Go to GitHub</linkAlternateText>
           <linkUri>https://GitHub.com/EWSoftware/SHFB</linkUri>
       </externalLink>

--- a/Documentation/ContentLayout.content
+++ b/Documentation/ContentLayout.content
@@ -46,7 +46,7 @@
       <Topic id="65a5d5bf-28d7-4450-91d9-b6fefe9d775c" visible="True" title="Version 5.0.1.0" />
       <Topic id="f97262f0-e8df-46e1-94b8-093926c445cb" visible="True" title="Version 5.0.2.0" />
     </Topic>
-    <Topic id="c4caecfe-e2ea-4c87-b602-75d6b57aa70b" visible="True" title="AntPlus Version History">
+    <Topic id="c4caecfe-e2ea-4c87-b602-75d6b57aa70b" visible="True" isExpanded="true" title="AntPlus Version History">
       <Topic id="b3754de5-1d8d-422e-9071-12d290d4b14d" visible="True" title="Version 2.0.0.0" />
       <Topic id="607e34e9-cdf4-4f9a-85c6-78f830e1aff8" visible="True" title="Version 2.1.0.0" />
       <Topic id="892f97e4-a593-403f-bcfe-1b546a86ed2d" visible="True" title="Version 2.2.0.0" />
@@ -64,6 +64,7 @@
       <Topic id="b747c524-6203-4a88-8d66-7ae0f14fbf2b" visible="True" title="Version 6.0.2.0" />
       <Topic id="f78a2341-be7d-4efc-85de-bb79cf438b13" visible="True" title="Version 6.0.3.0" />
       <Topic id="96dd3305-46d4-42b2-bfa0-0ccf90028989" visible="True" title="Version 6.0.4.0" />
+      <Topic id="2b295d47-8d19-4efd-8ed5-775da9613fab" visible="True" isSelected="true" title="Version 6.1.0.0" />
     </Topic>
     <Topic id="62db1666-31ce-45bd-9331-b6c3762dcffe" visible="True" title="AntUsbStick Version History">
       <Topic id="91a9ea80-f3a3-427f-ae9d-a021d19f6f46" visible="True" title="Version 2.0.2.0" />
@@ -78,7 +79,7 @@
       <Topic id="e7c024a9-cea5-46d9-b130-7525cf879b21" visible="True" title="Version 4.1.0.0" />
       <Topic id="9a0a79c5-37f2-4a2d-bf5a-b99df97604f0" visible="True" title="Version 4.1.1.0" />
     </Topic>
-    <Topic id="be2ad779-f723-47b4-a6ab-00691c896a8e" visible="True" isExpanded="true" title="Hosting Extensions Version History">
+    <Topic id="be2ad779-f723-47b4-a6ab-00691c896a8e" visible="True" title="Hosting Extensions Version History">
       <Topic id="0677519c-d5ba-4c5d-b400-f10dc75a33a7" visible="True" title="Version 1.0.0.0" />
       <Topic id="5c5fc223-4f8c-4a17-bb09-8f0d1d3f2cac" visible="True" title="Version 1.1.0.0" />
       <Topic id="69e0beb6-59b3-441e-95d7-3c51cc27aba3" visible="True" title="Version 1.1.1.0" />
@@ -89,7 +90,7 @@
       <Topic id="a6de64ac-a3c0-4220-a961-cef056a7732d" visible="True" title="Version 2.0.1.0" />
       <Topic id="39f4b138-eeba-4411-8cbc-ba4ee4163734" visible="True" title="Version 2.0.2.0" />
       <Topic id="e3907d72-92e2-49de-8c92-6969d124ef55" visible="True" title="Version 2.0.3.0" />
-      <Topic id="3b4e306d-50ae-416e-8b47-8ca8f6caa2ae" visible="True" isSelected="true" title="Version 2.0.4.0" />
+      <Topic id="3b4e306d-50ae-416e-8b47-8ca8f6caa2ae" visible="True" title="Version 2.0.4.0" />
     </Topic>
   </Topic>
 </Topics>

--- a/Documentation/Documentation.shfbproj
+++ b/Documentation/Documentation.shfbproj
@@ -137,6 +137,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="Content\VersionHistory\AntPlus\v6.0.4.0.aml" />
+    <None Include="Content\VersionHistory\AntPlus\v6.1.0.0.aml" />
     <None Include="Content\VersionHistory\AntRadioInterface\v5.0.2.0.aml" />
     <None Include="Content\VersionHistory\AntUsbStick\v4.1.1.0.aml" />
     <None Include="Content\VersionHistory\HostingExtensions\v2.0.3.0.aml" />


### PR DESCRIPTION
#### PR Classification
New feature and refactor: Adds support for the ANT+ Legacy Stationary Bike device profile, refactors lap toggle handling, and fixes treadmill state handling.

#### PR Summary
This PR introduces the StationaryBike device profile to the Fitness Equipment category, refactors lap toggle event handling for consistency, and fixes treadmill state management. It also adds targeted unit tests and updates documentation and dependencies.
- FitnessEquipment.cs: Adds StationaryBike support, refactors lap toggle logic into HandleFEState, and fixes treadmill state handling.
- StationaryBike.cs: Implements the new StationaryBike class with cadence and power parsing.
- FitnessEquipmentTests.cs and StationaryBikeTests.cs: Adds and updates unit tests for StationaryBike and lap toggle events.
- Updates enums (FitnessEquipmentType, DataPage) to include StationaryBike.
- Updates version to 6.1.0 and documentation/release notes.

Closes #121.