### PR TITLE
Add MauiAntGrpcClient to Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,7 @@ updates:
       - "/Examples/WpfUsbStickApp"
       - "/Examples/MAUI-gRPC/AntGrpcShared"
       - "/Examples/MAUI-gRPC/AntGrpcService"
+      - "/Examples/MAUI-gRPC/MauiAntGrpcClient"
     schedule:
       interval: "weekly"
       


### PR DESCRIPTION
MauiAntGrpClient previously failed dependency scanning. Test this again.