### PR TITLE
Handle Unknown Data Pages

### DIFF
--- a/AntPlus.Extensions.Hosting/Hosting.csproj
+++ b/AntPlus.Extensions.Hosting/Hosting.csproj
@@ -21,7 +21,7 @@
     </PackageReleaseNotes>
 	<IncludeSymbols>True</IncludeSymbols>
 	<SymbolPackageFormat>snupkg</SymbolPackageFormat>
-	<VersionPrefix>2.0.5</VersionPrefix>
+	<VersionPrefix>2.0.6</VersionPrefix>
 	<PackageProjectUrl>https://stephenhidem.github.io/AntPlus</PackageProjectUrl>
 	<RepositoryUrl>https://github.com/StephenHidem/AntPlus</RepositoryUrl>
 	<Configurations>Debug;Release</Configurations>

--- a/AntPlus.UnitTests/AntPlus.UnitTests.csproj
+++ b/AntPlus.UnitTests/AntPlus.UnitTests.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="coverlet.collector" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>

--- a/AntPlus.UnitTests/CommonDataPagesTests.cs
+++ b/AntPlus.UnitTests/CommonDataPagesTests.cs
@@ -26,8 +26,9 @@ namespace AntPlus.UnitTests
             // Arrange
             byte[] dataPage = [0x47, 0xFF, 0xFE, 0x04, 0x11, 0x22, 0x33, 0x44];
             // Act
-            _commonDataPages.ParseCommonDataPage(dataPage);
+            bool result = _commonDataPages.ParseCommonDataPage(dataPage);
             // Assert
+            Assert.True(result);
             Assert.Equal(0xFF, _commonDataPages.CommandStatus.LastCommandReceived);
             Assert.Equal(254, _commonDataPages.CommandStatus.SequenceNumber);
             Assert.Equal(CommonDataPages.CommandResult.Pending, _commonDataPages.CommandStatus.Status);
@@ -40,8 +41,9 @@ namespace AntPlus.UnitTests
             // Arrange
             byte[] dataPage = [0x50, 0xFF, 0xFF, 0x01, 0x0F, 0x00, 0x85, 0x83];
             // Act
-            _commonDataPages.ParseCommonDataPage(dataPage);
+            bool result = _commonDataPages.ParseCommonDataPage(dataPage);
             // Assert
+            Assert.True(result);
             Assert.Equal(0xFF, _commonDataPages.ManufacturerInfo.ComponentId);
             Assert.Equal(1, _commonDataPages.ManufacturerInfo.HardwareRevision);
             Assert.Equal(15, _commonDataPages.ManufacturerInfo.ManufacturerId);
@@ -54,8 +56,9 @@ namespace AntPlus.UnitTests
             // Arrange
             byte[] dataPage = [0x4E, 0xFF, 0x22, 0x01, 0x0F, 0x00, 0x85, 0x83];
             // Act
-            _commonDataPages.ParseCommonDataPage(dataPage);
+            bool result = _commonDataPages.ParseCommonDataPage(dataPage);
             // Assert
+            Assert.True(result);
             Assert.Equal(0x22, _commonDataPages.ManufacturerInfo.ComponentId);
             Assert.Equal(1, _commonDataPages.ManufacturerInfo.HardwareRevision);
             Assert.Equal(15, _commonDataPages.ManufacturerInfo.ManufacturerId);
@@ -70,10 +73,11 @@ namespace AntPlus.UnitTests
             // Act
             var currentCulture = CultureInfo.CurrentCulture;
             CultureInfo.CurrentCulture = new CultureInfo("ru-RU");
-            _commonDataPages.ParseCommonDataPage(dataPage);
+            bool result = _commonDataPages.ParseCommonDataPage(dataPage);
             CultureInfo.CurrentCulture = currentCulture;
 
             // Assert
+            Assert.True(result);
             Assert.Equal(0xFF, _commonDataPages.ProductInfo.ComponentId);
             Assert.Equal(serialNumber, _commonDataPages.ProductInfo.SerialNumber);
             Assert.True(_commonDataPages.ProductInfo.SoftwareRevision == Version.Parse(version));
@@ -85,8 +89,9 @@ namespace AntPlus.UnitTests
             // Arrange
             byte[] dataPage = [0x4F, 0x22, 0xFF, 12, 5, 6, 7, 8];
             // Act
-            _commonDataPages.ParseCommonDataPage(dataPage);
+            bool result = _commonDataPages.ParseCommonDataPage(dataPage);
             // Assert
+            Assert.True(result);
             Assert.Equal(0x22, _commonDataPages.ProductInfo.ComponentId);
             Assert.Equal((uint)0x08070605, _commonDataPages.ProductInfo.SerialNumber);
             Assert.True(_commonDataPages.ProductInfo.SoftwareRevision == Version.Parse("1.200"));
@@ -106,8 +111,9 @@ namespace AntPlus.UnitTests
             BatteryStatus batteryStatus, double voltage, byte count, byte id, uint operatingTimeInSeconds)
         {
             // Act
-            _commonDataPages.ParseCommonDataPage(dataPage);
+            bool result = _commonDataPages.ParseCommonDataPage(dataPage);
             // Assert
+            Assert.True(result);
             Assert.Equal(batteryStatus, _commonDataPages.BatteryStatus.Status);
             Assert.Equal(voltage, _commonDataPages.BatteryStatus.BatteryVoltage, 0.001);
             Assert.Equal(count, _commonDataPages.BatteryStatus.NumberOfBatteries);
@@ -121,8 +127,9 @@ namespace AntPlus.UnitTests
             // Arrange
             byte[] dataPage = [0x53, 0xFF, 0x0D, 0x1B, 0x11, 0x92, 0x06, 0x09];
             // Act
-            _commonDataPages.ParseCommonDataPage(dataPage);
+            bool result = _commonDataPages.ParseCommonDataPage(dataPage);
             // Assert
+            Assert.True(result);
             Assert.Equal(DateTime.Parse("06/18/2009 17:27:13", DateTimeFormatInfo.InvariantInfo), _commonDataPages.TimeAndDate);
         }
 
@@ -157,8 +164,9 @@ namespace AntPlus.UnitTests
             double subPage1Value, double subPage2Value)
         {
             // Act
-            _commonDataPages.ParseCommonDataPage(dataPage);
+            bool result = _commonDataPages.ParseCommonDataPage(dataPage);
             // Assert
+            Assert.True(result);
             Assert.Equal(subPage1, _commonDataPages.SubfieldData.Subpage1);
             Assert.Equal(subPage1Value, _commonDataPages.SubfieldData.ComputedDataField1, 0.01);
             Assert.Equal(subPage2, _commonDataPages.SubfieldData.Subpage2);
@@ -171,8 +179,9 @@ namespace AntPlus.UnitTests
         public void ParseSubfieldDataPage_InvalidSubPage_LogsError(byte[] dataPage)
         {
             // Act
-            _commonDataPages.ParseCommonDataPage(dataPage);
+            bool result = _commonDataPages.ParseCommonDataPage(dataPage);
             // Assert
+            Assert.True(result);
             _mockLogger.Verify(
                 x => x.Log(
                     LogLevel.Warning,
@@ -193,8 +202,9 @@ namespace AntPlus.UnitTests
         public void ParseMemoryLevelPage_PropertiesCorrect(byte[] dataPage, CommonDataPages.MemorySizeUnit sizeUnit)
         {
             // Act
-            _commonDataPages.ParseCommonDataPage(dataPage);
+            bool result = _commonDataPages.ParseCommonDataPage(dataPage);
             // Assert
+            Assert.True(result);
             Assert.Equal(55.0, _commonDataPages.MemoryLevel.PercentUsed, 0.5);
             Assert.Equal(3276.8, _commonDataPages.MemoryLevel.TotalSize, 0.1);
             Assert.Equal(sizeUnit, _commonDataPages.MemoryLevel.TotalSizeUnit);
@@ -206,8 +216,9 @@ namespace AntPlus.UnitTests
             // Arrange
             byte[] dataPage = [0x56, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF];
             // Act
-            _commonDataPages.ParseCommonDataPage(dataPage);
+            bool result = _commonDataPages.ParseCommonDataPage(dataPage);
             // Assert
+            Assert.True(result);
             _mockLogger.Verify(
                 x => x.Log(
                     LogLevel.Warning,
@@ -224,8 +235,9 @@ namespace AntPlus.UnitTests
         public void ParseErrorDescriptionPage_PropertiesCorrect(byte[] dataPage, CommonDataPages.ErrorLevel errorLevel)
         {
             // Act
-            _commonDataPages.ParseCommonDataPage(dataPage);
+            bool result = _commonDataPages.ParseCommonDataPage(dataPage);
             // Assert
+            Assert.True(result);
             Assert.Equal(errorLevel, _commonDataPages.ErrorDescription.ErrorLevel);
             Assert.Equal(0xF, _commonDataPages.ErrorDescription.SystemComponentIndex);
             Assert.Equal(0xFF, _commonDataPages.ErrorDescription.ProfileSpecificErrorCode);
@@ -233,21 +245,14 @@ namespace AntPlus.UnitTests
         }
 
         [Fact]
-        public void ParseUnknownDataPage_LogsWarning()
+        public void ParseUnknownDataPage_ReturnsFalse()
         {
             // Arrange
             byte[] dataPage = [0x58, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF];
             // Act
-            _commonDataPages.ParseCommonDataPage(dataPage);
+            bool result = _commonDataPages.ParseCommonDataPage(dataPage);
             // Assert
-            _mockLogger.Verify(
-                x => x.Log(
-                    LogLevel.Warning,
-                    It.IsAny<EventId>(),
-                    It.Is<It.IsAnyType>((v, t) => v.ToString().Contains("Unknown data page")),
-                    null,
-                    It.IsAny<Func<It.IsAnyType, Exception, string>>()),
-                Times.Once);
+            Assert.False(result);
         }
 
         [Fact]

--- a/AntPlus.UnitTests/DeviceProfiles/AssetTracker/AssetTrackerTests.cs
+++ b/AntPlus.UnitTests/DeviceProfiles/AssetTracker/AssetTrackerTests.cs
@@ -1,7 +1,9 @@
 ﻿using Microsoft.Extensions.Logging;
 using Moq;
 using SmallEarthTech.AntPlus.DeviceProfiles.AssetTracker;
+using SmallEarthTech.AntPlus.DeviceProfiles.BicyclePower;
 using SmallEarthTech.AntRadioInterface;
+using System;
 using System.Collections.Generic;
 using Xunit;
 
@@ -17,6 +19,7 @@ namespace AntPlus.UnitTests.DeviceProfiles.AssetTracker
         {
             _mockAntChannel = new Mock<IAntChannel> { CallBase = true };
             _mockLogger = new Mock<ILogger<Tracker>>();
+            _mockLogger.Setup(l => l.IsEnabled(It.IsAny<LogLevel>())).Returns(true);
             _tracker = new Tracker(new ChannelId(0), _mockAntChannel.Object, _mockLogger.Object, It.IsAny<int>());
         }
 
@@ -161,6 +164,29 @@ namespace AntPlus.UnitTests.DeviceProfiles.AssetTracker
 
             // Assert
             Assert.True(_tracker.Disconnected);
+        }
+
+        [Fact]
+        public void Parse_UnknownDataPage_RaisedUnknownDataPageEvent()
+        {
+            // Arrange
+            byte[] dataPage = [0xFF, 0, 0, 0, 0, 0, 0, 0];
+            byte[] receivedData = null;
+            _tracker.UnknownDataPageReceived += (s, d) => receivedData = d;
+
+            // Act
+            _tracker.Parse(dataPage);
+
+            // Assert
+            Assert.Equal(dataPage, receivedData);
+            _mockLogger.Verify(
+                x => x.Log(
+                    LogLevel.Warning,
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((v, t) => v.ToString().Contains("Unknown data page")),
+                    null,
+                    It.IsAny<Func<It.IsAnyType, Exception, string>>()),
+                Times.Once);
         }
     }
 }

--- a/AntPlus.UnitTests/DeviceProfiles/BicyclePower/CrankTorqueFrequencySensorTests.cs
+++ b/AntPlus.UnitTests/DeviceProfiles/BicyclePower/CrankTorqueFrequencySensorTests.cs
@@ -54,6 +54,29 @@ namespace AntPlus.UnitTests.DeviceProfiles.BicyclePowerTests
         }
 
         [Fact]
+        public void ParseUnknownDataPage_CallsOnUnknownDataPageReceived()
+        {
+            // Arrange
+            byte[] dataPage = [0xFF, 0, 0, 0, 0, 0, 0, 0];
+            byte[] receivedData = null;
+            _crankTorqueFrequencySensor.UnknownDataPageReceived += (s, d) => receivedData = d;
+
+            // Act
+            _crankTorqueFrequencySensor.Parse(dataPage);
+
+            // Assert
+            Assert.Equal(dataPage, receivedData);
+            _mockLogger.Verify(
+                x => x.Log(
+                    LogLevel.Warning,
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((v, t) => v.ToString().Contains("Unknown data page")),
+                    null,
+                    It.IsAny<Func<It.IsAnyType, Exception, string>>()),
+                Times.Once);
+        }
+
+        [Fact]
         public async Task SaveSlopeToFlash_MessageFormatCorrect()
         {
             // Arrange

--- a/AntPlus.UnitTests/DeviceProfiles/BicyclePower/StandardCrankTorqueSensorTests.cs
+++ b/AntPlus.UnitTests/DeviceProfiles/BicyclePower/StandardCrankTorqueSensorTests.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
+using SmallEarthTech.AntPlus.DeviceProfiles.AssetTracker;
 using SmallEarthTech.AntPlus.DeviceProfiles.BicyclePower;
 using SmallEarthTech.AntRadioInterface;
 using System;

--- a/AntPlus.UnitTests/DeviceProfiles/BicyclePower/StandardPowerSensorTests.cs
+++ b/AntPlus.UnitTests/DeviceProfiles/BicyclePower/StandardPowerSensorTests.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
+using SmallEarthTech.AntPlus.DeviceProfiles.AssetTracker;
 using SmallEarthTech.AntPlus.DeviceProfiles.BicyclePower;
 using SmallEarthTech.AntRadioInterface;
 using Xunit;
@@ -72,6 +73,21 @@ namespace AntPlus.UnitTests.DeviceProfiles.BicyclePowerTests
 
             // Assert
             Assert.Equal(8721, _standardPowerSensor.AveragePower);
+        }
+
+        [Fact]
+        public void Parse_UnknownDataPage_RaisedUnknownDataPageEvent()
+        {
+            // Arrange
+            byte[] dataPage = [0xFF, 0, 0, 0, 0, 0, 0, 0];
+            byte[] receivedData = null;
+            _standardPowerSensor.UnknownDataPageReceived += (s, d) => receivedData = d;
+
+            // Act
+            _standardPowerSensor.Parse(dataPage);
+
+            // Assert
+            Assert.Equal(dataPage, receivedData);
         }
     }
 }

--- a/AntPlus.UnitTests/DeviceProfiles/BikeSpeedAndCadence/BikeCadenceSensorTests.cs
+++ b/AntPlus.UnitTests/DeviceProfiles/BikeSpeedAndCadence/BikeCadenceSensorTests.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.Logging;
 using Moq;
+using SmallEarthTech.AntPlus.DeviceProfiles.BicyclePower;
 using SmallEarthTech.AntPlus.DeviceProfiles.BikeSpeedAndCadence;
 using SmallEarthTech.AntRadioInterface;
 using Xunit;
@@ -29,6 +30,21 @@ namespace AntPlus.UnitTests.DeviceProfiles.BikeSpeedAndCadence
 
             // Assert
             Assert.Equal(120, _sensor.InstantaneousCadence);
+        }
+
+        [Fact]
+        public void Parse_UnknownDataPage_RaisedUnknownDataPageEvent()
+        {
+            // Arrange
+            byte[] dataPage = [0xFF, 0, 0, 0, 0, 0, 0, 0];
+            byte[] receivedData = null;
+            _sensor.UnknownDataPageReceived += (s, d) => receivedData = d;
+
+            // Act
+            _sensor.Parse(dataPage);
+
+            // Assert
+            Assert.Equal(dataPage, receivedData);
         }
     }
 }

--- a/AntPlus.UnitTests/DeviceProfiles/BikeSpeedAndCadence/BikeSpeedSensorTests.cs
+++ b/AntPlus.UnitTests/DeviceProfiles/BikeSpeedAndCadence/BikeSpeedSensorTests.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.Logging;
 using Moq;
+using SmallEarthTech.AntPlus.DeviceProfiles.BicyclePower;
 using SmallEarthTech.AntPlus.DeviceProfiles.BikeSpeedAndCadence;
 using SmallEarthTech.AntRadioInterface;
 using Xunit;
@@ -30,6 +31,21 @@ namespace AntPlus.UnitTests.DeviceProfiles.BikeSpeedAndCadence
             // Assert
             Assert.Equal(11, _sensor.InstantaneousSpeed);
             Assert.Equal(11, _sensor.AccumulatedDistance);
+        }
+
+        [Fact]
+        public void Parse_UnknownDataPage_RaisedUnknownDataPageEvent()
+        {
+            // Arrange
+            byte[] dataPage = [0xFF, 0, 0, 0, 0, 0, 0, 0];
+            byte[] receivedData = null;
+            _sensor.UnknownDataPageReceived += (s, d) => receivedData = d;
+
+            // Act
+            _sensor.Parse(dataPage);
+
+            // Assert
+            Assert.Equal(dataPage, receivedData);
         }
     }
 }

--- a/AntPlus.UnitTests/DeviceProfiles/FitnessEquipment/ClimberTests.cs
+++ b/AntPlus.UnitTests/DeviceProfiles/FitnessEquipment/ClimberTests.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.Logging;
 using Moq;
+using SmallEarthTech.AntPlus.DeviceProfiles.BicyclePower;
 using SmallEarthTech.AntPlus.DeviceProfiles.FitnessEquipment;
 using SmallEarthTech.AntRadioInterface;
 using Xunit;
@@ -57,6 +58,21 @@ namespace AntPlus.UnitTests.DeviceProfiles.FitnessEquipment
 
             // Assert
             Assert.Equal(20, _climber.StrideCycles);
+        }
+
+        [Fact]
+        public void Parse_UnknownDataPage_RaisedUnknownDataPageEvent()
+        {
+            // Arrange
+            byte[] dataPage = [0xFF, 0, 0, 0, 0, 0, 0, 0];
+            byte[] receivedData = null;
+            _climber.UnknownDataPageReceived += (s, d) => receivedData = d;
+
+            // Act
+            _climber.Parse(dataPage);
+
+            // Assert
+            Assert.Equal(dataPage, receivedData);
         }
     }
 }

--- a/AntPlus.UnitTests/DeviceProfiles/FitnessEquipment/EllipticalTests.cs
+++ b/AntPlus.UnitTests/DeviceProfiles/FitnessEquipment/EllipticalTests.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.Logging;
 using Moq;
+using SmallEarthTech.AntPlus.DeviceProfiles.BicyclePower;
 using SmallEarthTech.AntPlus.DeviceProfiles.FitnessEquipment;
 using SmallEarthTech.AntRadioInterface;
 using Xunit;
@@ -74,6 +75,21 @@ namespace AntPlus.UnitTests.DeviceProfiles.FitnessEquipment
 
             // Assert
             Assert.Equal(capabilities, _elliptical.Capabilities);
+        }
+
+        [Fact]
+        public void Parse_UnknownDataPage_RaisedUnknownDataPageEvent()
+        {
+            // Arrange
+            byte[] dataPage = [0xFF, 0, 0, 0, 0, 0, 0, 0];
+            byte[] receivedData = null;
+            _elliptical.UnknownDataPageReceived += (s, d) => receivedData = d;
+
+            // Act
+            _elliptical.Parse(dataPage);
+
+            // Assert
+            Assert.Equal(dataPage, receivedData);
         }
     }
 }

--- a/AntPlus.UnitTests/DeviceProfiles/FitnessEquipment/NordicSkierTests.cs
+++ b/AntPlus.UnitTests/DeviceProfiles/FitnessEquipment/NordicSkierTests.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.Logging;
 using Moq;
+using SmallEarthTech.AntPlus.DeviceProfiles.BicyclePower;
 using SmallEarthTech.AntPlus.DeviceProfiles.FitnessEquipment;
 using SmallEarthTech.AntRadioInterface;
 using Xunit;
@@ -57,6 +58,21 @@ namespace AntPlus.UnitTests.DeviceProfiles.FitnessEquipment
 
             // Assert
             Assert.Equal(capabilities, _skier.Capabilities);
+        }
+
+        [Fact]
+        public void Parse_UnknownDataPage_RaisedUnknownDataPageEvent()
+        {
+            // Arrange
+            byte[] dataPage = [0xFF, 0, 0, 0, 0, 0, 0, 0];
+            byte[] receivedData = null;
+            _skier.UnknownDataPageReceived += (s, d) => receivedData = d;
+
+            // Act
+            _skier.Parse(dataPage);
+
+            // Assert
+            Assert.Equal(dataPage, receivedData);
         }
     }
 }

--- a/AntPlus.UnitTests/DeviceProfiles/FitnessEquipment/RowerTests.cs
+++ b/AntPlus.UnitTests/DeviceProfiles/FitnessEquipment/RowerTests.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.Logging;
 using Moq;
+using SmallEarthTech.AntPlus.DeviceProfiles.BicyclePower;
 using SmallEarthTech.AntPlus.DeviceProfiles.FitnessEquipment;
 using SmallEarthTech.AntRadioInterface;
 using Xunit;
@@ -57,6 +58,21 @@ namespace AntPlus.UnitTests.DeviceProfiles.FitnessEquipment
 
             // Assert
             Assert.Equal(capabilities, _rower.Capabilities);
+        }
+
+        [Fact]
+        public void Parse_UnknownDataPage_RaisedUnknownDataPageEvent()
+        {
+            // Arrange
+            byte[] dataPage = [0xFF, 0, 0, 0, 0, 0, 0, 0];
+            byte[] receivedData = null;
+            _rower.UnknownDataPageReceived += (s, d) => receivedData = d;
+
+            // Act
+            _rower.Parse(dataPage);
+
+            // Assert
+            Assert.Equal(dataPage, receivedData);
         }
     }
 }

--- a/AntPlus.UnitTests/DeviceProfiles/FitnessEquipment/StationaryBikeTests.cs
+++ b/AntPlus.UnitTests/DeviceProfiles/FitnessEquipment/StationaryBikeTests.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.Logging;
 using Moq;
+using SmallEarthTech.AntPlus.DeviceProfiles.BicyclePower;
 using SmallEarthTech.AntPlus.DeviceProfiles.FitnessEquipment;
 using SmallEarthTech.AntRadioInterface;
 using Xunit;
@@ -51,6 +52,21 @@ namespace AntPlus.UnitTests.DeviceProfiles.FitnessEquipment
 
             // Act & Assert - should not throw
             _stationaryBike.Parse(dataPage);
+        }
+
+        [Fact]
+        public void Parse_UnknownDataPage_RaisedUnknownDataPageEvent()
+        {
+            // Arrange
+            byte[] dataPage = [0xFF, 0, 0, 0, 0, 0, 0, 0];
+            byte[] receivedData = null;
+            _stationaryBike.UnknownDataPageReceived += (s, d) => receivedData = d;
+
+            // Act
+            _stationaryBike.Parse(dataPage);
+
+            // Assert
+            Assert.Equal(dataPage, receivedData);
         }
 
         [Fact]

--- a/AntPlus.UnitTests/DeviceProfiles/FitnessEquipment/TrainerStationaryBikeTests.cs
+++ b/AntPlus.UnitTests/DeviceProfiles/FitnessEquipment/TrainerStationaryBikeTests.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.Logging;
 using Moq;
+using SmallEarthTech.AntPlus.DeviceProfiles.BicyclePower;
 using SmallEarthTech.AntPlus.DeviceProfiles.FitnessEquipment;
 using SmallEarthTech.AntRadioInterface;
 using System;
@@ -225,6 +226,21 @@ namespace AntPlus.UnitTests.DeviceProfiles.FitnessEquipment
 
             // Assert
             Assert.Equal(32768, _trainer.TargetSpinDownTime);
+        }
+
+        [Fact]
+        public void Parse_UnknownDataPage_RaisedUnknownDataPageEvent()
+        {
+            // Arrange
+            byte[] dataPage = [0xFF, 0, 0, 0, 0, 0, 0, 0];
+            byte[] receivedData = null;
+            _trainer.UnknownDataPageReceived += (s, d) => receivedData = d;
+
+            // Act
+            _trainer.Parse(dataPage);
+
+            // Assert
+            Assert.Equal(dataPage, receivedData);
         }
 
         [Fact]

--- a/AntPlus.UnitTests/DeviceProfiles/FitnessEquipment/TreadmillTests.cs
+++ b/AntPlus.UnitTests/DeviceProfiles/FitnessEquipment/TreadmillTests.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.Logging;
 using Moq;
+using SmallEarthTech.AntPlus.DeviceProfiles.BicyclePower;
 using SmallEarthTech.AntPlus.DeviceProfiles.FitnessEquipment;
 using SmallEarthTech.AntRadioInterface;
 using Xunit;
@@ -74,6 +75,21 @@ namespace AntPlus.UnitTests.DeviceProfiles.FitnessEquipment
 
             // Assert
             Assert.Equal(capabilities, _treadmill.Capabilities);
+        }
+
+        [Fact]
+        public void Parse_UnknownDataPage_RaisedUnknownDataPageEvent()
+        {
+            // Arrange
+            byte[] dataPage = [0xFF, 0, 0, 0, 0, 0, 0, 0];
+            byte[] receivedData = null;
+            _treadmill.UnknownDataPageReceived += (s, d) => receivedData = d;
+
+            // Act
+            _treadmill.Parse(dataPage);
+
+            // Assert
+            Assert.Equal(dataPage, receivedData);
         }
     }
 }

--- a/AntPlus.UnitTests/DeviceProfiles/GeocacheTests.cs
+++ b/AntPlus.UnitTests/DeviceProfiles/GeocacheTests.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Extensions.Logging;
 using Moq;
 using SmallEarthTech.AntPlus.DeviceProfiles;
+using SmallEarthTech.AntPlus.DeviceProfiles.BicyclePower;
 using SmallEarthTech.AntRadioInterface;
 using System;
 using System.Collections.Generic;
@@ -90,6 +91,21 @@ namespace AntPlus.UnitTests.DeviceProfiles
             Assert.Equal(MessagingReturnCode.Pass, result);
             Assert.True(token.SequenceEqual(_geocache.AuthenticationToken),
                 string.Format("Expected {0}, Actual {1}", BitConverter.ToString(token), BitConverter.ToString(_geocache.AuthenticationToken)));
+        }
+
+        [Fact]
+        public void Parse_UnknownDataPage_RaisedUnknownDataPageEvent()
+        {
+            // Arrange
+            byte[] dataPage = [0xFF, 0, 0, 0, 0, 0, 0, 0];
+            byte[] receivedData = null;
+            _geocache.UnknownDataPageReceived += (s, d) => receivedData = d;
+
+            // Act
+            _geocache.Parse(dataPage);
+
+            // Assert
+            Assert.Equal(dataPage, receivedData);
         }
 
         [Fact]

--- a/AntPlus.UnitTests/DeviceProfiles/HeartRateTests.cs
+++ b/AntPlus.UnitTests/DeviceProfiles/HeartRateTests.cs
@@ -16,11 +16,14 @@ namespace AntPlus.UnitTests.DeviceProfiles
 
         private readonly ChannelId cid = new(0);
         private readonly Mock<IAntChannel> _mockAntChannel;
+        private Mock<ILogger<HeartRate>> _mockLogger;
 
         public HeartRateTests()
         {
+            _mockLogger = new Mock<ILogger<HeartRate>>();
+            _mockLogger.Setup(l => l.IsEnabled(It.IsAny<LogLevel>())).Returns(true);
             _mockAntChannel = new();
-            _heartRate = new(cid, _mockAntChannel.Object, Mock.Of<ILogger<HeartRate>>(), It.IsAny<int>());
+            _heartRate = new(cid, _mockAntChannel.Object, _mockLogger.Object, It.IsAny<int>());
         }
 
         [Fact]
@@ -216,6 +219,30 @@ namespace AntPlus.UnitTests.DeviceProfiles
 
             // Assert
             Assert.Equal(expEventType, _heartRate.EventType);
+        }
+
+        [Fact]
+        public void Parse_UnrecognizedDataPage_RaisedUnknownDataPageReceived()
+        {
+            // Arrange
+            _heartRate.Parse([0x0A, 0, 0, 0, 0xAA, 0x55, 0x33, 70]);
+            byte[] dataPage = [0x8A, 0, 0, 0, 0xAA, 0x55, 0x33, 70];
+            byte[] receivedData = null;
+            _heartRate.UnknownDataPageReceived += (s, d) => receivedData = d;
+
+            // Act
+            _heartRate.Parse(dataPage);
+
+            // Assert
+            Assert.Equal(dataPage, receivedData);
+            _mockLogger.Verify(
+                x => x.Log(
+                    LogLevel.Warning,
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((v, t) => v.ToString().Contains("Unknown data page")),
+                    null,
+                    It.IsAny<Func<It.IsAnyType, Exception, string>>()),
+                Times.Once);
         }
 
         [Fact]

--- a/AntPlus.UnitTests/DeviceProfiles/MuscleOxygenTests.cs
+++ b/AntPlus.UnitTests/DeviceProfiles/MuscleOxygenTests.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Extensions.Logging;
 using Moq;
 using SmallEarthTech.AntPlus.DeviceProfiles;
+using SmallEarthTech.AntPlus.DeviceProfiles.BicyclePower;
 using SmallEarthTech.AntRadioInterface;
 using System;
 using System.Threading.Tasks;
@@ -102,6 +103,21 @@ namespace AntPlus.UnitTests.DeviceProfiles
             // Assert
             Assert.Equal(concentration, _muscleOxygen.CurrentSaturatedHemoglobin.PercentSaturated);
             Assert.Equal(status, _muscleOxygen.CurrentSaturatedHemoglobin.Status);
+        }
+
+        [Fact]
+        public void Parse_UnknownDataPage_RaisedUnknownDataPageEvent()
+        {
+            // Arrange
+            byte[] dataPage = [0xFF, 0, 0, 0, 0, 0, 0, 0];
+            byte[] receivedData = null;
+            _muscleOxygen.UnknownDataPageReceived += (s, d) => receivedData = d;
+
+            // Act
+            _muscleOxygen.Parse(dataPage);
+
+            // Assert
+            Assert.Equal(dataPage, receivedData);
         }
 
         [Theory]

--- a/AntPlus.UnitTests/DeviceProfiles/StrideBasedSpeedAndDistanceTests.cs
+++ b/AntPlus.UnitTests/DeviceProfiles/StrideBasedSpeedAndDistanceTests.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Extensions.Logging;
 using Moq;
 using SmallEarthTech.AntPlus.DeviceProfiles;
+using SmallEarthTech.AntPlus.DeviceProfiles.BicyclePower;
 using SmallEarthTech.AntRadioInterface;
 using Xunit;
 using static SmallEarthTech.AntPlus.DeviceProfiles.StrideBasedSpeedAndDistance;
@@ -176,6 +177,21 @@ namespace AntPlus.UnitTests.DeviceProfiles
 
             // Assert
             Assert.Equal(useState, _strideBasedSpeedAndDistance.Status.State);
+        }
+
+        [Fact]
+        public void Parse_UnknownDataPage_RaisedUnknownDataPageEvent()
+        {
+            // Arrange
+            byte[] dataPage = [0xFF, 0, 0, 0, 0, 0, 0, 0];
+            byte[] receivedData = null;
+            _strideBasedSpeedAndDistance.UnknownDataPageReceived += (s, d) => receivedData = d;
+
+            // Act
+            _strideBasedSpeedAndDistance.Parse(dataPage);
+
+            // Assert
+            Assert.Equal(dataPage, receivedData);
         }
     }
 }

--- a/AntPlus/AntDevice.cs
+++ b/AntPlus/AntDevice.cs
@@ -66,6 +66,10 @@ namespace SmallEarthTech.AntPlus
         /// <remarks>
         /// Raised when a data page with an unrecognized identifier or format is encountered;
         /// subscribers receive the raw bytes via the <c>EventHandler&lt;byte[]&gt;</c> argument.
+        /// <para>
+        /// Unrecognized data pages may indicate new features implemented by the device manufacturer, and this event
+        /// allows consumers to process the data pages if the format is known.
+        /// </para>
         /// </remarks>
         public event EventHandler<byte[]>? UnknownDataPageReceived;
 

--- a/AntPlus/AntDevice.cs
+++ b/AntPlus/AntDevice.cs
@@ -60,6 +60,15 @@ namespace SmallEarthTech.AntPlus
         /// <value>The device image stream.</value>
         public abstract Stream? DeviceImageStream { get; }
 
+        /// <summary>
+        /// Occurs when an unrecognized data page is received and provides the raw page bytes to subscribers.
+        /// </summary>
+        /// <remarks>
+        /// Raised when a data page with an unrecognized identifier or format is encountered;
+        /// subscribers receive the raw bytes via the <c>EventHandler&lt;byte[]&gt;</c> argument.
+        /// </remarks>
+        public event EventHandler<byte[]>? UnknownDataPageReceived;
+
         /// <summary>Initializes a new instance of the <see cref="AntDevice" /> class.</summary>
         /// <param name="channelId">The channel identifier.</param>
         /// <param name="antChannel">Channel to send messages to.</param>
@@ -107,7 +116,7 @@ namespace SmallEarthTech.AntPlus
         {
             Offline = true;
             Dispose();
-            DeviceWentOffline?.Invoke(this, new EventArgs());
+            DeviceWentOffline?.Invoke(this, EventArgs.Empty);
         }
 
         /// <summary>Parses the specified data page.</summary>
@@ -158,6 +167,28 @@ namespace SmallEarthTech.AntPlus
         {
             MessagingReturnCode ret = await _antChannel.SendExtAcknowledgedDataAsync(ChannelId, message, (uint)_deviceTimeout);
             return ret;
+        }
+
+        /// <summary>
+        /// Raises the <see cref="UnknownDataPageReceived"/> event with the provided raw data page bytes.
+        /// </summary>
+        /// <param name="dataPage">Raw bytes of the unrecognized data page.</param>
+        protected virtual void OnUnknownDataPageReceived(byte[] dataPage)
+        {
+            _logger.LogUnknownDataPage(dataPage);
+            UnknownDataPageReceived?.Invoke(this, dataPage);
+        }
+
+        /// <summary>
+        /// Raises the <see cref="UnknownDataPageReceived"/> event with the provided raw data page bytes and includes the data page identifier in the log.
+        /// </summary>
+        /// <typeparam name="TEnum">The enumeration that was being parsed.</typeparam>
+        /// <param name="unknownDataPageId">The identifier of the unrecognized data page.</param>
+        /// <param name="dataPage">The raw bytes of the unrecognized data page.</param>
+        protected virtual void OnUnknownDataPageReceived<TEnum>(byte unknownDataPageId, byte[] dataPage) where TEnum : Enum
+        {
+            _logger.LogUnknownDataPage<TEnum>(unknownDataPageId, dataPage);
+            UnknownDataPageReceived?.Invoke(this, dataPage);
         }
 
         /// <summary>

--- a/AntPlus/AntPlus.csproj
+++ b/AntPlus/AntPlus.csproj
@@ -5,7 +5,7 @@
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <RootNamespace>SmallEarthTech.$(MSBuildProjectName.Replace(" ", "_"))</RootNamespace>
     <PackageId>SmallEarthTech.$(AssemblyName)</PackageId>
-    <VersionPrefix>6.1.0</VersionPrefix>
+    <VersionPrefix>6.2.0</VersionPrefix>
     <Title>ANT+ Class Library</Title>
     <PackageProjectUrl>https://stephenhidem.github.io/AntPlus</PackageProjectUrl>
     <Authors>Stephen Hidem</Authors>
@@ -23,10 +23,8 @@
 	<PackageIcon>PackageLogo.png</PackageIcon>
 	<PackageReadmeFile>readme.md</PackageReadmeFile>
 	<PackageReleaseNotes>
-		1. New device profile: Legacy Stationary Bike added to Fitness Equipment category.
-		2. Refactor: HandleFEState handles lap toggle.
-		3. Bug fix: Treadmill now correctly handles fitness equipment state.
-		4. Updated NuGet dependencies.
+		1. Added UnknownDataPageReceived event to AntDevice class. This allows applications to receive data pages that are not defined in the library. This is useful for receiving custom data pages or data pages that have not yet been added to the library.
+		2. Updated NuGet dependencies.
 	</PackageReleaseNotes>
 	<Configurations>Debug;Release</Configurations>
   </PropertyGroup>

--- a/AntPlus/CommonDataPages.cs
+++ b/AntPlus/CommonDataPages.cs
@@ -434,9 +434,12 @@ namespace SmallEarthTech.AntPlus
             _logger = logger;
         }
 
-        /// <summary>Parses the common data page.</summary>
+        /// <summary>
+        /// Parses common data pages.
+        /// </summary>
         /// <param name="dataPage">The data page.</param>
-        public void ParseCommonDataPage(byte[] dataPage)
+        /// <returns>Returns true if the data page was successfully parsed as a common data page, false otherwise.</returns>
+        public bool ParseCommonDataPage(byte[] dataPage)
         {
             switch ((CommonDataPage)dataPage[0])
             {
@@ -470,9 +473,9 @@ namespace SmallEarthTech.AntPlus
                     ErrorDescription = new ErrorDescriptionPage(dataPage);
                     break;
                 default:
-                    _logger.LogUnknownDataPage(dataPage);
-                    break;
+                    return false;
             }
+            return true;
         }
 
         /// <summary>Formats the generic command page.</summary>

--- a/AntPlus/DeviceProfiles/AssetTracker/Tracker.cs
+++ b/AntPlus/DeviceProfiles/AssetTracker/Tracker.cs
@@ -125,7 +125,11 @@ namespace SmallEarthTech.AntPlus.DeviceProfiles.AssetTracker
                     Disconnected = true;
                     break;
                 default:
-                    CommonDataPages.ParseCommonDataPage(dataPage);
+                    // Handle common data pages and unknown data pages.
+                    if (!CommonDataPages.ParseCommonDataPage(dataPage))
+                    {
+                        OnUnknownDataPageReceived(dataPage);
+                    }
                     break;
             }
         }

--- a/AntPlus/DeviceProfiles/BicyclePower/BicyclePower.cd
+++ b/AntPlus/DeviceProfiles/BicyclePower/BicyclePower.cd
@@ -2,8 +2,15 @@
 <ClassDiagram MajorVersion="1" MinorVersion="1">
   <Class Name="SmallEarthTech.AntPlus.DeviceProfiles.BicyclePower.BicyclePower" Collapsed="true">
     <Position X="2.5" Y="3" Width="1.5" />
+    <NestedTypes>
+      <Enum Name="SmallEarthTech.AntPlus.DeviceProfiles.BicyclePower.BicyclePower.DataPage" Collapsed="true">
+        <TypeIdentifier>
+          <NewMemberFileName>DeviceProfiles\BicyclePower\BicyclePower.cs</NewMemberFileName>
+        </TypeIdentifier>
+      </Enum>
+    </NestedTypes>
     <TypeIdentifier>
-      <HashCode>AAAAAAAAAAABAAAAAAAABAAAAAAQAAAAAAAAAAAQAAA=</HashCode>
+      <HashCode>AACAAAAAAAABAAAAAAAABAAAAAAQAAAAAAAAAAAQAAA=</HashCode>
       <FileName>DeviceProfiles\BicyclePower\BicyclePower.cs</FileName>
     </TypeIdentifier>
   </Class>
@@ -29,18 +36,6 @@
     <Compartments>
       <Compartment Name="Nested Types" Collapsed="false" />
     </Compartments>
-    <NestedTypes>
-      <Struct Name="SmallEarthTech.AntPlus.DeviceProfiles.BicyclePower.StandardCrankTorqueSensor.ForceAngle" Collapsed="true">
-        <TypeIdentifier>
-          <NewMemberFileName>DeviceProfiles\BicyclePower\StandardCrankTorqueSensor.cs</NewMemberFileName>
-        </TypeIdentifier>
-      </Struct>
-      <Struct Name="SmallEarthTech.AntPlus.DeviceProfiles.BicyclePower.StandardCrankTorqueSensor.PedalPositionPage" Collapsed="true">
-        <TypeIdentifier>
-          <NewMemberFileName>DeviceProfiles\BicyclePower\StandardCrankTorqueSensor.cs</NewMemberFileName>
-        </TypeIdentifier>
-      </Struct>
-    </NestedTypes>
     <TypeIdentifier>
       <HashCode>AAAAAAAAAAAAgEAEAAAAAIAAAAAAAwAAABgAAAAAAAA=</HashCode>
       <FileName>DeviceProfiles\BicyclePower\StandardCrankTorqueSensor.cs</FileName>
@@ -51,28 +46,6 @@
     <Compartments>
       <Compartment Name="Nested Types" Collapsed="false" />
     </Compartments>
-    <NestedTypes>
-      <Struct Name="SmallEarthTech.AntPlus.DeviceProfiles.BicyclePower.StandardPowerSensor.CrankParameters" Collapsed="true">
-        <TypeIdentifier>
-          <NewMemberFileName>DeviceProfiles\BicyclePower\Parameters.cs</NewMemberFileName>
-        </TypeIdentifier>
-      </Struct>
-      <Struct Name="SmallEarthTech.AntPlus.DeviceProfiles.BicyclePower.StandardPowerSensor.AdvCapabilities1" Collapsed="true">
-        <TypeIdentifier>
-          <NewMemberFileName>DeviceProfiles\BicyclePower\Parameters.cs</NewMemberFileName>
-        </TypeIdentifier>
-      </Struct>
-      <Struct Name="SmallEarthTech.AntPlus.DeviceProfiles.BicyclePower.StandardPowerSensor.AdvCapabilities2" Collapsed="true">
-        <TypeIdentifier>
-          <NewMemberFileName>DeviceProfiles\BicyclePower\Parameters.cs</NewMemberFileName>
-        </TypeIdentifier>
-      </Struct>
-      <Enum Name="SmallEarthTech.AntPlus.DeviceProfiles.BicyclePower.StandardPowerSensor.PedalDifferentiation" Collapsed="true">
-        <TypeIdentifier>
-          <NewMemberFileName>DeviceProfiles\BicyclePower\StandardPowerSensor.cs</NewMemberFileName>
-        </TypeIdentifier>
-      </Enum>
-    </NestedTypes>
     <TypeIdentifier>
       <HashCode>AACgAIAEAKBECACEAAGASAlBAANAAdACABQSkgSJCQA=</HashCode>
       <FileName>DeviceProfiles\BicyclePower\Calibration.cs</FileName>
@@ -95,7 +68,7 @@
   <Class Name="SmallEarthTech.AntPlus.AntDevice" Collapsed="true">
     <Position X="2.5" Y="2" Width="1.5" />
     <TypeIdentifier>
-      <HashCode>AACgAgAAACEAAAAGAAABIAAIAARAAAACAAQAAEAAAAA=</HashCode>
+      <HashCode>AACkIAAAACEAAAAEAAADIAAIIARAAAAABAQAAAgAAAA=</HashCode>
       <FileName>AntDevice.cs</FileName>
     </TypeIdentifier>
     <Lollipop Position="0.2" />

--- a/AntPlus/DeviceProfiles/BicyclePower/Calibration.cs
+++ b/AntPlus/DeviceProfiles/BicyclePower/Calibration.cs
@@ -103,7 +103,7 @@ namespace SmallEarthTech.AntPlus.DeviceProfiles.BicyclePower
                     CustomCalibrationParameters = page.Skip(2).ToArray();
                     break;
                 default:
-                    _logger.LogUnknownDataPage<CalibrationResponseId>(page[1], page);
+                    OnUnknownDataPageReceived<CalibrationResponseId>(page[1], page);
                     break;
             }
         }

--- a/AntPlus/DeviceProfiles/BicyclePower/CrankTorqueFrequencySensor.cs
+++ b/AntPlus/DeviceProfiles/BicyclePower/CrankTorqueFrequencySensor.cs
@@ -84,7 +84,7 @@ namespace SmallEarthTech.AntPlus.DeviceProfiles.BicyclePower
                     ParseCTFMessage(dataPage);
                     break;
                 default:
-                    _logger.LogUnknownDataPage(dataPage);
+                    OnUnknownDataPageReceived(dataPage);
                     break;
             }
         }
@@ -147,18 +147,18 @@ namespace SmallEarthTech.AntPlus.DeviceProfiles.BicyclePower
                                 _logger.LogDataPage<CTFDefinedId>(LogLevel.Debug, dataPage[3], dataPage);
                                 break;
                             default:
-                                _logger.LogUnknownDataPage<CTFDefinedId>(dataPage[3], dataPage);
+                                OnUnknownDataPageReceived<CTFDefinedId>(dataPage[3], dataPage);
                                 break;
                         }
                         break;
                     default:
-                        _logger.LogUnknownDataPage<CTFDefinedId>(dataPage[2], dataPage);
+                        OnUnknownDataPageReceived<CTFDefinedId>(dataPage[2], dataPage);
                         break;
                 }
             }
             else
             {
-                _logger.LogUnknownDataPage<CalibrationResponseId>(dataPage[1], dataPage);
+                OnUnknownDataPageReceived<CalibrationResponseId>(dataPage[1], dataPage);
             }
         }
 

--- a/AntPlus/DeviceProfiles/BicyclePower/Parameters.cs
+++ b/AntPlus/DeviceProfiles/BicyclePower/Parameters.cs
@@ -253,7 +253,7 @@ namespace SmallEarthTech.AntPlus.DeviceProfiles.BicyclePower
                     AdvancedCapabilities2 = new AdvCapabilities2(dataPage);
                     break;
                 default:
-                    _logger.LogUnknownDataPage<SubPage>(dataPage[1], dataPage);
+                    OnUnknownDataPageReceived<SubPage>(dataPage[1], dataPage);
                     break;
             }
         }

--- a/AntPlus/DeviceProfiles/BicyclePower/StandardPowerSensor.cs
+++ b/AntPlus/DeviceProfiles/BicyclePower/StandardPowerSensor.cs
@@ -125,7 +125,11 @@ namespace SmallEarthTech.AntPlus.DeviceProfiles.BicyclePower
                     }
                     break;
                 default:
-                    CommonDataPages.ParseCommonDataPage(dataPage);
+                    // attempt to parse common data pages, otherwise log as unknown
+                    if (!CommonDataPages.ParseCommonDataPage(dataPage))
+                    {
+                        OnUnknownDataPageReceived(dataPage);
+                    }
                     break;
             }
         }

--- a/AntPlus/DeviceProfiles/BikeSpeedAndCadence/CommonSpeedCadence.cs
+++ b/AntPlus/DeviceProfiles/BikeSpeedAndCadence/CommonSpeedCadence.cs
@@ -181,7 +181,7 @@ namespace SmallEarthTech.AntPlus.DeviceProfiles.BikeSpeedAndCadence
                     Stopped = dataPage[1] == 0x01;
                     break;
                 default:
-                    _logger.LogUnknownDataPage(dataPage);
+                    OnUnknownDataPageReceived(dataPage);
                     break;
             }
         }

--- a/AntPlus/DeviceProfiles/FitnessEquipment/Climber.cs
+++ b/AntPlus/DeviceProfiles/FitnessEquipment/Climber.cs
@@ -75,7 +75,11 @@ namespace SmallEarthTech.AntPlus.DeviceProfiles.FitnessEquipment
             }
             else
             {
-                CommonDataPages.ParseCommonDataPage(dataPage);
+                // Attempt to parse the data page as a common data page. If it fails, raise the unknown data page event.
+                if (!CommonDataPages.ParseCommonDataPage(dataPage))
+                {
+                    OnUnknownDataPageReceived(dataPage);
+                }
             }
         }
 

--- a/AntPlus/DeviceProfiles/FitnessEquipment/Elliptical.cs
+++ b/AntPlus/DeviceProfiles/FitnessEquipment/Elliptical.cs
@@ -86,7 +86,11 @@ namespace SmallEarthTech.AntPlus.DeviceProfiles.FitnessEquipment
             }
             else
             {
-                CommonDataPages.ParseCommonDataPage(dataPage);
+                // Attempt to parse the data page as a common data page. If it fails, raise the unknown data page event.
+                if (!CommonDataPages.ParseCommonDataPage(dataPage))
+                {
+                    OnUnknownDataPageReceived(dataPage);
+                }
             }
         }
 

--- a/AntPlus/DeviceProfiles/FitnessEquipment/FitnessEquipment.cs
+++ b/AntPlus/DeviceProfiles/FitnessEquipment/FitnessEquipment.cs
@@ -375,7 +375,7 @@ namespace SmallEarthTech.AntPlus.DeviceProfiles.FitnessEquipment
             }
             else
             {
-                _logger.LogUnknownDataPage<FEState>(dataPage[7], dataPage);
+                OnUnknownDataPageReceived<FEState>(dataPage[7], dataPage);
             }
         }
 

--- a/AntPlus/DeviceProfiles/FitnessEquipment/NordicSkier.cs
+++ b/AntPlus/DeviceProfiles/FitnessEquipment/NordicSkier.cs
@@ -77,7 +77,11 @@ namespace SmallEarthTech.AntPlus.DeviceProfiles.FitnessEquipment
             }
             else
             {
-                CommonDataPages.ParseCommonDataPage(dataPage);
+                // Attempt to parse the data page as a common data page. If it fails, raise the unknown data page event.
+                if (!CommonDataPages.ParseCommonDataPage(dataPage))
+                {
+                    OnUnknownDataPageReceived(dataPage);
+                }
             }
         }
     }

--- a/AntPlus/DeviceProfiles/FitnessEquipment/Rower.cs
+++ b/AntPlus/DeviceProfiles/FitnessEquipment/Rower.cs
@@ -77,7 +77,11 @@ namespace SmallEarthTech.AntPlus.DeviceProfiles.FitnessEquipment
             }
             else
             {
-                CommonDataPages.ParseCommonDataPage(dataPage);
+                // Attempt to parse the data page as a common data page. If it fails, raise the unknown data page event.
+                if (!CommonDataPages.ParseCommonDataPage(dataPage))
+                {
+                    OnUnknownDataPageReceived(dataPage);
+                }
             }
         }
 

--- a/AntPlus/DeviceProfiles/FitnessEquipment/StationaryBike.cs
+++ b/AntPlus/DeviceProfiles/FitnessEquipment/StationaryBike.cs
@@ -51,7 +51,11 @@ namespace SmallEarthTech.AntPlus.DeviceProfiles.FitnessEquipment
             }
             else
             {
-                CommonDataPages.ParseCommonDataPage(dataPage);
+                // Attempt to parse the data page as a common data page. If it fails, raise the unknown data page event.
+                if (!CommonDataPages.ParseCommonDataPage(dataPage))
+                {
+                    OnUnknownDataPageReceived(dataPage);
+                }
             }
         }
 

--- a/AntPlus/DeviceProfiles/FitnessEquipment/TrainerStationaryBike.cs
+++ b/AntPlus/DeviceProfiles/FitnessEquipment/TrainerStationaryBike.cs
@@ -249,7 +249,11 @@ namespace SmallEarthTech.AntPlus.DeviceProfiles.FitnessEquipment
                     TrainerTorque.Parse(dataPage);
                     break;
                 default:
-                    CommonDataPages.ParseCommonDataPage(dataPage);
+                    // Attempt to parse the data page as a common data page. If it fails, raise the unknown data page event.
+                    if (!CommonDataPages.ParseCommonDataPage(dataPage))
+                    {
+                        OnUnknownDataPageReceived(dataPage);
+                    }
                     break;
             }
         }

--- a/AntPlus/DeviceProfiles/FitnessEquipment/Treadmill.cs
+++ b/AntPlus/DeviceProfiles/FitnessEquipment/Treadmill.cs
@@ -82,7 +82,11 @@ namespace SmallEarthTech.AntPlus.DeviceProfiles.FitnessEquipment
             }
             else
             {
-                CommonDataPages.ParseCommonDataPage(dataPage);
+                // Attempt to parse the data page as a common data page. If it fails, raise the unknown data page event.
+                if (!CommonDataPages.ParseCommonDataPage(dataPage))
+                {
+                    OnUnknownDataPageReceived(dataPage);
+                }
             }
         }
 

--- a/AntPlus/DeviceProfiles/Geocache.cs
+++ b/AntPlus/DeviceProfiles/Geocache.cs
@@ -174,13 +174,17 @@ namespace SmallEarthTech.AntPlus.DeviceProfiles
                                 else { LastVisitTimestamp = null; }
                                 break;
                             default:
-                                _logger.LogUnknownDataPage<DataId>(dataPage[1], dataPage);
+                                OnUnknownDataPageReceived<DataId>(dataPage[1], dataPage);
                                 break;
                         }
                     }
                     else
                     {
-                        CommonDataPages.ParseCommonDataPage(dataPage);
+                        // Attempt to parse the data page as a common data page. If it fails, raise the unknown data page event.
+                        if (!CommonDataPages.ParseCommonDataPage(dataPage))
+                        {
+                            OnUnknownDataPageReceived(dataPage);
+                        }
                     }
                     break;
             }

--- a/AntPlus/DeviceProfiles/HeartRate.cs
+++ b/AntPlus/DeviceProfiles/HeartRate.cs
@@ -389,7 +389,7 @@ namespace SmallEarthTech.AntPlus.DeviceProfiles
                     }
                     else
                     {
-                        _logger.LogUnknownDataPage(dataPage);
+                        OnUnknownDataPageReceived(dataPage);
                     }
                     break;
             }

--- a/AntPlus/DeviceProfiles/MuscleOxygen.cs
+++ b/AntPlus/DeviceProfiles/MuscleOxygen.cs
@@ -211,7 +211,11 @@ namespace SmallEarthTech.AntPlus.DeviceProfiles
                     CurrentSaturatedHemoglobin = shg;
                     break;
                 default:
-                    CommonDataPages.ParseCommonDataPage(dataPage);
+                    // Attempt to parse the data page as a common data page. If it fails, raise the unknown data page event.
+                    if (!CommonDataPages.ParseCommonDataPage(dataPage))
+                    {
+                        OnUnknownDataPageReceived(dataPage);
+                    }
                     break;
             }
         }

--- a/AntPlus/DeviceProfiles/StrideBasedSpeedAndDistance.cs
+++ b/AntPlus/DeviceProfiles/StrideBasedSpeedAndDistance.cs
@@ -267,7 +267,11 @@ namespace SmallEarthTech.AntPlus.DeviceProfiles
                     Capabilities = (CapabilitiesFlags)dataPage[1];
                     break;
                 default:
-                    CommonDataPages.ParseCommonDataPage(dataPage);
+                    // Attempt to parse the data page as a common data page. If it fails, raise the unknown data page event.
+                    if (!CommonDataPages.ParseCommonDataPage(dataPage))
+                    {
+                        OnUnknownDataPageReceived(dataPage);
+                    }
                     break;
             }
         }

--- a/AntRadioInterface/AntRadioInterface.csproj
+++ b/AntRadioInterface/AntRadioInterface.csproj
@@ -7,7 +7,7 @@
     <PackageId>SmallEarthTech.$(AssemblyName)</PackageId>
     <Authors>Stephen Hidem</Authors>
     <Title>ANT+ Radio Interface Class Library</Title>
-    <VersionPrefix>5.0.3</VersionPrefix>
+    <VersionPrefix>5.0.4</VersionPrefix>
     <Copyright>© $(Authors) 2023. All rights reserved.</Copyright>
     <PackageProjectUrl>https://stephenhidem.github.io/AntPlus</PackageProjectUrl>
     <PackageTags>ant; ant+; antplus; dynastream; smallearthtech</PackageTags>

--- a/Documentation/Content/AntPlusOverview.aml
+++ b/Documentation/Content/AntPlusOverview.aml
@@ -107,10 +107,44 @@
 			<title>AntDevice</title>
 			<content>
 				<para>
-					This abstract class provides properties and methods common to all ANT devices. The virtual Parse method handles resetting the
-					device timeout each time a message is received. The RequestDataPage method sends a data page request to the ANT device.
-					The SendExtAcknowledgedMessage method sends commands/requests to the ANT device.
+					This abstract class provides events, properties and methods common to all ANT devices. These are some of the key
+					features of this class that are used by the derived ANT device classes -
 				</para>
+				<list class="bullet">
+					<listItem>
+						<para>
+							The virtual <c>Parse</c> method handles resetting the device timeout each time a message is received. Derived
+							classes should override this method to parse messages received from the ANT device. Be sure to call the
+							base Parse method to reset the device timeout.
+						</para>
+					</listItem>
+					<listItem>
+						<para>
+							The <c>RequestDataPage</c> method sends a data page request to the ANT device. The derived classes
+							typically provide a public method that calls this method with the appropriate data page number for the
+							request.
+						</para>
+					</listItem>
+					<listItem>
+						<para>
+							The <c>SendExtAcknowledgedMessage</c> method sends commands/requests to the ANT device. The derived classes
+							typically provide public methods that call this method with the appropriate data page number and payload
+							for the command/request.
+						</para>
+					</listItem>
+					<listItem>
+						<para>
+							The <c>DeviceOffline</c> event is raised when the ANT device timeout is reached. The timeout options are
+							configured in the AntDeviceCollection class.
+						</para>
+					</listItem>
+					<listItem>
+						<para>
+							The <c>UnknownDataPageReceived</c> event is raised when a data page is received that is not defined in the
+							library. This allows applications to receive custom data pages or data pages that supported by the library.
+						</para>
+					</listItem>
+				</list>
 			</content>
 		</section>
 		<section>

--- a/Documentation/Content/VersionHistory/AntPlus/AntPllusVersionHistory.aml
+++ b/Documentation/Content/VersionHistory/AntPlus/AntPllusVersionHistory.aml
@@ -116,6 +116,11 @@
 							<link xlink:href="2b295d47-8d19-4efd-8ed5-775da9613fab" />
 						</para>
 					</listItem>
+					<listItem>
+						<para>
+							<link xlink:href="dbfcdb2d-f917-448a-8dc5-317d3a1bc097" />
+						</para>
+					</listItem>
 				</list>
       	</content>
       <!-- If a section contains a sections element, its content creates

--- a/Documentation/Content/VersionHistory/AntPlus/v6.2.0.0.aml
+++ b/Documentation/Content/VersionHistory/AntPlus/v6.2.0.0.aml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<topic id="62db1666-31ce-45bd-9331-b6c3762dcffe" revisionNumber="1">
+<topic id="dbfcdb2d-f917-448a-8dc5-317d3a1bc097" revisionNumber="1">
   <developerConceptualDocument
     xmlns="http://ddue.schemas.microsoft.com/authoring/2003/5"
     xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -17,82 +17,26 @@
            zero (0) to limit it to top-level sections only.  -->
       <!-- <autoOutline /> -->
 
-      <para>Version 2.0.1.0 was released on January 3, 2024.</para>
+      <para>Release Date: May 31, 2026</para>
     </introduction>
 
     <!-- Add one or more top-level section elements.  These are collapsible.
          If using <autoOutline />, add an address attribute to identify it
          and specify a title so that it can be jumped to with a hyperlink. -->
     <section address="Section1">
+      <title>Changes</title>
       <content>
-				<list class="bullet">
-					<listItem>
-						<para>
-							<link xlink:href="91a9ea80-f3a3-427f-ae9d-a021d19f6f46" />
-						</para>
-					</listItem>
-					<listItem>
-						<para>
-							<link xlink:href="c4f39db8-d602-4e2d-a75e-fc72afbc47c5" />
-						</para>
-					</listItem>
-					<listItem>
-						<para>
-							<link xlink:href="ea422e45-03fe-4b1d-bc19-280e03ea4729" />
-						</para>
-					</listItem>
-					<listItem>
-						<para>
-							<link xlink:href="01235973-8fca-4be5-9fb3-13e8fe5b03b3" />
-						</para>
-					</listItem>
-					<listItem>
-						<para>
-							<link xlink:href="59808fa5-1390-4c46-8696-d3e7e4a379a5" />
-						</para>
-					</listItem>
-					<listItem>
-						<para>
-							<link xlink:href="eddb9b97-fd16-47e3-9c18-64883ca4ef55" />
-						</para>
-					</listItem>
-					<listItem>
-						<para>
-							<link xlink:href="501a56d8-5811-4359-98d3-8b00850aed6c" />						
-						</para>					
-					</listItem>
-					<listItem>
-						<para>
-							<link xlink:href="0edbd450-f2c3-41cd-9e24-fc4505fc5823" />
-						</para>
-					</listItem>
-					<listItem>
-						<para>
-							<link xlink:href="896d67b1-6f79-4b99-82c8-1b17748ad9bd" />
-						</para>
-					</listItem>
-					<listItem>
-						<para>
-							<link xlink:href="e7c024a9-cea5-46d9-b130-7525cf879b21" />
-						</para>
-					</listItem>
-					<listItem>
-						<para>
-							<link xlink:href="9a0a79c5-37f2-4a2d-bf5a-b99df97604f0" />
-						</para>
-					</listItem>
-					<listItem>
-                        <para>
-                            <link xlink:href="c180c7d6-8e94-472e-b6f6-cf4f31dd2570" />
-						</para>
-					</listItem>
-					<listItem>
-						<para>
-							<link xlink:href="05845fcc-1268-458b-a391-3d3fb1362115" />
-						</para>
-					</listItem>
-				</list>
-      </content>
+        <!-- Uncomment this to create a sub-section outline
+        <autoOutline /> -->
+		  <list class="bullet">
+			  <listItem>
+				  <para>Added UnknownDataPageReceived event to AntDevice class. This allows applications to receive data pages that are not defined in the library. This is useful for receiving custom data pages or data pages that have not yet been added to the library.</para>
+			  </listItem>
+			  <listItem>
+				  <para>Updated NuGet dependencies to latest version.</para>
+			  </listItem>
+		  </list>
+	  </content>
       <!-- If a section contains a sections element, its content creates
            sub-sections.  These are not collapsible.
       <sections>
@@ -112,8 +56,8 @@
     </section>
 
     <relatedTopics>
-			<link xlink:href="4a8ae1c2-5d9b-4e27-bd18-34b479401b65" />
-			<!-- One or more of the following:
+		<link xlink:href="c4caecfe-e2ea-4c87-b602-75d6b57aa70b" />
+		<!-- One or more of the following:
            - A local link
            - An external link
            - A code entity reference
@@ -135,7 +79,7 @@
       <link xlink:href="00e97994-e9e6-46e0-b420-5be86b2f8278">Some other topic</link>
 
       <externalLink>
-          <linkText>SHFB on GitHub</linkText>
+          <linkText>Sandcastle Help File Builder on GitHub</linkText>
           <linkAlternateText>Go to GitHub</linkAlternateText>
           <linkUri>https://GitHub.com/EWSoftware/SHFB</linkUri>
       </externalLink>

--- a/Documentation/Content/VersionHistory/AntRadioInterface/AntRadioInterfaceVersionHistory.aml
+++ b/Documentation/Content/VersionHistory/AntRadioInterface/AntRadioInterfaceVersionHistory.aml
@@ -81,6 +81,11 @@
                     <link xlink:href="80d46562-f520-4b0a-9e44-2ef6d542f2b3"/>
 				</para>
 			</listItem>
+			<listItem>
+				<para>
+					<link xlink:href="203d5ff6-7327-46e1-8add-27092f77fe0a"/>
+				</para>
+			</listItem>
 		</list>
       </content>
       <!-- If a section contains a sections element, its content creates

--- a/Documentation/Content/VersionHistory/AntRadioInterface/v5.0.4.0.aml
+++ b/Documentation/Content/VersionHistory/AntRadioInterface/v5.0.4.0.aml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<topic id="62db1666-31ce-45bd-9331-b6c3762dcffe" revisionNumber="1">
+<topic id="203d5ff6-7327-46e1-8add-27092f77fe0a" revisionNumber="1">
   <developerConceptualDocument
     xmlns="http://ddue.schemas.microsoft.com/authoring/2003/5"
     xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -17,82 +17,23 @@
            zero (0) to limit it to top-level sections only.  -->
       <!-- <autoOutline /> -->
 
-      <para>Version 2.0.1.0 was released on January 3, 2024.</para>
+      <para>Release Date: May 31, 2026</para>
     </introduction>
 
     <!-- Add one or more top-level section elements.  These are collapsible.
          If using <autoOutline />, add an address attribute to identify it
          and specify a title so that it can be jumped to with a hyperlink. -->
     <section address="Section1">
+      <title>Changes</title>
       <content>
-				<list class="bullet">
-					<listItem>
-						<para>
-							<link xlink:href="91a9ea80-f3a3-427f-ae9d-a021d19f6f46" />
-						</para>
-					</listItem>
-					<listItem>
-						<para>
-							<link xlink:href="c4f39db8-d602-4e2d-a75e-fc72afbc47c5" />
-						</para>
-					</listItem>
-					<listItem>
-						<para>
-							<link xlink:href="ea422e45-03fe-4b1d-bc19-280e03ea4729" />
-						</para>
-					</listItem>
-					<listItem>
-						<para>
-							<link xlink:href="01235973-8fca-4be5-9fb3-13e8fe5b03b3" />
-						</para>
-					</listItem>
-					<listItem>
-						<para>
-							<link xlink:href="59808fa5-1390-4c46-8696-d3e7e4a379a5" />
-						</para>
-					</listItem>
-					<listItem>
-						<para>
-							<link xlink:href="eddb9b97-fd16-47e3-9c18-64883ca4ef55" />
-						</para>
-					</listItem>
-					<listItem>
-						<para>
-							<link xlink:href="501a56d8-5811-4359-98d3-8b00850aed6c" />						
-						</para>					
-					</listItem>
-					<listItem>
-						<para>
-							<link xlink:href="0edbd450-f2c3-41cd-9e24-fc4505fc5823" />
-						</para>
-					</listItem>
-					<listItem>
-						<para>
-							<link xlink:href="896d67b1-6f79-4b99-82c8-1b17748ad9bd" />
-						</para>
-					</listItem>
-					<listItem>
-						<para>
-							<link xlink:href="e7c024a9-cea5-46d9-b130-7525cf879b21" />
-						</para>
-					</listItem>
-					<listItem>
-						<para>
-							<link xlink:href="9a0a79c5-37f2-4a2d-bf5a-b99df97604f0" />
-						</para>
-					</listItem>
-					<listItem>
-                        <para>
-                            <link xlink:href="c180c7d6-8e94-472e-b6f6-cf4f31dd2570" />
-						</para>
-					</listItem>
-					<listItem>
-						<para>
-							<link xlink:href="05845fcc-1268-458b-a391-3d3fb1362115" />
-						</para>
-					</listItem>
-				</list>
-      </content>
+        <!-- Uncomment this to create a sub-section outline
+        <autoOutline /> -->
+		  <list class="bullet">
+			  <listItem>
+				  <para>Updated NuGet dependencies.</para>
+			  </listItem>
+		  </list>
+	  </content>
       <!-- If a section contains a sections element, its content creates
            sub-sections.  These are not collapsible.
       <sections>
@@ -112,8 +53,8 @@
     </section>
 
     <relatedTopics>
-			<link xlink:href="4a8ae1c2-5d9b-4e27-bd18-34b479401b65" />
-			<!-- One or more of the following:
+		<link xlink:href="55b5d927-4d00-4e63-9f70-4f35a796c423"/>
+		<!-- One or more of the following:
            - A local link
            - An external link
            - A code entity reference
@@ -135,7 +76,7 @@
       <link xlink:href="00e97994-e9e6-46e0-b420-5be86b2f8278">Some other topic</link>
 
       <externalLink>
-          <linkText>SHFB on GitHub</linkText>
+          <linkText>Sandcastle Help File Builder on GitHub</linkText>
           <linkAlternateText>Go to GitHub</linkAlternateText>
           <linkUri>https://GitHub.com/EWSoftware/SHFB</linkUri>
       </externalLink>

--- a/Documentation/Content/VersionHistory/AntUsbStick/v4.1.3.0.aml
+++ b/Documentation/Content/VersionHistory/AntUsbStick/v4.1.3.0.aml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<topic id="62db1666-31ce-45bd-9331-b6c3762dcffe" revisionNumber="1">
+<topic id="05845fcc-1268-458b-a391-3d3fb1362115" revisionNumber="1">
   <developerConceptualDocument
     xmlns="http://ddue.schemas.microsoft.com/authoring/2003/5"
     xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -17,82 +17,25 @@
            zero (0) to limit it to top-level sections only.  -->
       <!-- <autoOutline /> -->
 
-      <para>Version 2.0.1.0 was released on January 3, 2024.</para>
+      <para>Release Date: May 31, 2026</para>
     </introduction>
 
     <!-- Add one or more top-level section elements.  These are collapsible.
          If using <autoOutline />, add an address attribute to identify it
          and specify a title so that it can be jumped to with a hyperlink. -->
     <section address="Section1">
+      <title>Changes</title>
       <content>
-				<list class="bullet">
-					<listItem>
-						<para>
-							<link xlink:href="91a9ea80-f3a3-427f-ae9d-a021d19f6f46" />
-						</para>
-					</listItem>
-					<listItem>
-						<para>
-							<link xlink:href="c4f39db8-d602-4e2d-a75e-fc72afbc47c5" />
-						</para>
-					</listItem>
-					<listItem>
-						<para>
-							<link xlink:href="ea422e45-03fe-4b1d-bc19-280e03ea4729" />
-						</para>
-					</listItem>
-					<listItem>
-						<para>
-							<link xlink:href="01235973-8fca-4be5-9fb3-13e8fe5b03b3" />
-						</para>
-					</listItem>
-					<listItem>
-						<para>
-							<link xlink:href="59808fa5-1390-4c46-8696-d3e7e4a379a5" />
-						</para>
-					</listItem>
-					<listItem>
-						<para>
-							<link xlink:href="eddb9b97-fd16-47e3-9c18-64883ca4ef55" />
-						</para>
-					</listItem>
-					<listItem>
-						<para>
-							<link xlink:href="501a56d8-5811-4359-98d3-8b00850aed6c" />						
-						</para>					
-					</listItem>
-					<listItem>
-						<para>
-							<link xlink:href="0edbd450-f2c3-41cd-9e24-fc4505fc5823" />
-						</para>
-					</listItem>
-					<listItem>
-						<para>
-							<link xlink:href="896d67b1-6f79-4b99-82c8-1b17748ad9bd" />
-						</para>
-					</listItem>
-					<listItem>
-						<para>
-							<link xlink:href="e7c024a9-cea5-46d9-b130-7525cf879b21" />
-						</para>
-					</listItem>
-					<listItem>
-						<para>
-							<link xlink:href="9a0a79c5-37f2-4a2d-bf5a-b99df97604f0" />
-						</para>
-					</listItem>
-					<listItem>
-                        <para>
-                            <link xlink:href="c180c7d6-8e94-472e-b6f6-cf4f31dd2570" />
-						</para>
-					</listItem>
-					<listItem>
-						<para>
-							<link xlink:href="05845fcc-1268-458b-a391-3d3fb1362115" />
-						</para>
-					</listItem>
-				</list>
-      </content>
+        <!-- Uncomment this to create a sub-section outline
+        <autoOutline /> -->
+		  <list class="bullet">
+			  <listItem>
+				  <para>
+					  Updated NuGet dependencies to latest version.
+				  </para>
+			  </listItem>
+		  </list>
+	  </content>
       <!-- If a section contains a sections element, its content creates
            sub-sections.  These are not collapsible.
       <sections>
@@ -112,8 +55,8 @@
     </section>
 
     <relatedTopics>
-			<link xlink:href="4a8ae1c2-5d9b-4e27-bd18-34b479401b65" />
-			<!-- One or more of the following:
+		<link xlink:href="62db1666-31ce-45bd-9331-b6c3762dcffe" />
+		<!-- One or more of the following:
            - A local link
            - An external link
            - A code entity reference
@@ -135,7 +78,7 @@
       <link xlink:href="00e97994-e9e6-46e0-b420-5be86b2f8278">Some other topic</link>
 
       <externalLink>
-          <linkText>SHFB on GitHub</linkText>
+          <linkText>Sandcastle Help File Builder on GitHub</linkText>
           <linkAlternateText>Go to GitHub</linkAlternateText>
           <linkUri>https://GitHub.com/EWSoftware/SHFB</linkUri>
       </externalLink>

--- a/Documentation/Content/VersionHistory/HostingExtensions/HostingExtensionsVersionHistory.aml
+++ b/Documentation/Content/VersionHistory/HostingExtensions/HostingExtensionsVersionHistory.aml
@@ -86,6 +86,11 @@
 							<link xlink:href="4a56e6e7-8563-43f6-8653-394ddb5bb534" />
 						</para>
 					</listItem>
+					<listItem>
+						<para>
+							<link xlink:href="86cba777-87f7-4203-a004-1e5abf8e6254" />
+						</para>
+					</listItem>
 				</list>
         <!-- Uncomment this to create a sub-section outline
         <autoOutline /> -->

--- a/Documentation/Content/VersionHistory/HostingExtensions/v2.0.6.0.aml
+++ b/Documentation/Content/VersionHistory/HostingExtensions/v2.0.6.0.aml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<topic id="62db1666-31ce-45bd-9331-b6c3762dcffe" revisionNumber="1">
+<topic id="86cba777-87f7-4203-a004-1e5abf8e6254" revisionNumber="1">
   <developerConceptualDocument
     xmlns="http://ddue.schemas.microsoft.com/authoring/2003/5"
     xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -17,82 +17,25 @@
            zero (0) to limit it to top-level sections only.  -->
       <!-- <autoOutline /> -->
 
-      <para>Version 2.0.1.0 was released on January 3, 2024.</para>
+      <para>Release Date: May 31, 2026</para>
     </introduction>
 
     <!-- Add one or more top-level section elements.  These are collapsible.
          If using <autoOutline />, add an address attribute to identify it
          and specify a title so that it can be jumped to with a hyperlink. -->
     <section address="Section1">
+      <title>Changes</title>
       <content>
-				<list class="bullet">
-					<listItem>
-						<para>
-							<link xlink:href="91a9ea80-f3a3-427f-ae9d-a021d19f6f46" />
-						</para>
-					</listItem>
-					<listItem>
-						<para>
-							<link xlink:href="c4f39db8-d602-4e2d-a75e-fc72afbc47c5" />
-						</para>
-					</listItem>
-					<listItem>
-						<para>
-							<link xlink:href="ea422e45-03fe-4b1d-bc19-280e03ea4729" />
-						</para>
-					</listItem>
-					<listItem>
-						<para>
-							<link xlink:href="01235973-8fca-4be5-9fb3-13e8fe5b03b3" />
-						</para>
-					</listItem>
-					<listItem>
-						<para>
-							<link xlink:href="59808fa5-1390-4c46-8696-d3e7e4a379a5" />
-						</para>
-					</listItem>
-					<listItem>
-						<para>
-							<link xlink:href="eddb9b97-fd16-47e3-9c18-64883ca4ef55" />
-						</para>
-					</listItem>
-					<listItem>
-						<para>
-							<link xlink:href="501a56d8-5811-4359-98d3-8b00850aed6c" />						
-						</para>					
-					</listItem>
-					<listItem>
-						<para>
-							<link xlink:href="0edbd450-f2c3-41cd-9e24-fc4505fc5823" />
-						</para>
-					</listItem>
-					<listItem>
-						<para>
-							<link xlink:href="896d67b1-6f79-4b99-82c8-1b17748ad9bd" />
-						</para>
-					</listItem>
-					<listItem>
-						<para>
-							<link xlink:href="e7c024a9-cea5-46d9-b130-7525cf879b21" />
-						</para>
-					</listItem>
-					<listItem>
-						<para>
-							<link xlink:href="9a0a79c5-37f2-4a2d-bf5a-b99df97604f0" />
-						</para>
-					</listItem>
-					<listItem>
-                        <para>
-                            <link xlink:href="c180c7d6-8e94-472e-b6f6-cf4f31dd2570" />
-						</para>
-					</listItem>
-					<listItem>
-						<para>
-							<link xlink:href="05845fcc-1268-458b-a391-3d3fb1362115" />
-						</para>
-					</listItem>
-				</list>
-      </content>
+        <!-- Uncomment this to create a sub-section outline
+        <autoOutline /> -->
+		  <list class="bullet">
+			  <listItem>
+				  <para>
+					  Updated NuGet dependencies to latest version.
+				  </para>
+			  </listItem>
+		  </list>
+	  </content>
       <!-- If a section contains a sections element, its content creates
            sub-sections.  These are not collapsible.
       <sections>
@@ -112,8 +55,8 @@
     </section>
 
     <relatedTopics>
-			<link xlink:href="4a8ae1c2-5d9b-4e27-bd18-34b479401b65" />
-			<!-- One or more of the following:
+		<link xlink:href="be2ad779-f723-47b4-a6ab-00691c896a8e" />
+		<!-- One or more of the following:
            - A local link
            - An external link
            - A code entity reference
@@ -135,7 +78,7 @@
       <link xlink:href="00e97994-e9e6-46e0-b420-5be86b2f8278">Some other topic</link>
 
       <externalLink>
-          <linkText>SHFB on GitHub</linkText>
+          <linkText>Sandcastle Help File Builder on GitHub</linkText>
           <linkAlternateText>Go to GitHub</linkAlternateText>
           <linkUri>https://GitHub.com/EWSoftware/SHFB</linkUri>
       </externalLink>

--- a/Documentation/ContentLayout.content
+++ b/Documentation/ContentLayout.content
@@ -46,6 +46,7 @@
       <Topic id="65a5d5bf-28d7-4450-91d9-b6fefe9d775c" visible="True" title="Version 5.0.1.0" />
       <Topic id="f97262f0-e8df-46e1-94b8-093926c445cb" visible="True" title="Version 5.0.2.0" />
       <Topic id="80d46562-f520-4b0a-9e44-2ef6d542f2b3" visible="True" title="Version 5.0.3.0" />
+      <Topic id="203d5ff6-7327-46e1-8add-27092f77fe0a" visible="True" title="Version 5.0.4.0" />
     </Topic>
     <Topic id="c4caecfe-e2ea-4c87-b602-75d6b57aa70b" visible="True" title="AntPlus Version History">
       <Topic id="b3754de5-1d8d-422e-9071-12d290d4b14d" visible="True" title="Version 2.0.0.0" />
@@ -66,6 +67,7 @@
       <Topic id="f78a2341-be7d-4efc-85de-bb79cf438b13" visible="True" title="Version 6.0.3.0" />
       <Topic id="96dd3305-46d4-42b2-bfa0-0ccf90028989" visible="True" title="Version 6.0.4.0" />
       <Topic id="2b295d47-8d19-4efd-8ed5-775da9613fab" visible="True" title="Version 6.1.0.0" />
+      <Topic id="dbfcdb2d-f917-448a-8dc5-317d3a1bc097" visible="True" title="Version 6.2.0.0" />
     </Topic>
     <Topic id="62db1666-31ce-45bd-9331-b6c3762dcffe" visible="True" title="AntUsbStick Version History">
       <Topic id="91a9ea80-f3a3-427f-ae9d-a021d19f6f46" visible="True" title="Version 2.0.2.0" />
@@ -80,6 +82,7 @@
       <Topic id="e7c024a9-cea5-46d9-b130-7525cf879b21" visible="True" title="Version 4.1.0.0" />
       <Topic id="9a0a79c5-37f2-4a2d-bf5a-b99df97604f0" visible="True" title="Version 4.1.1.0" />
       <Topic id="c180c7d6-8e94-472e-b6f6-cf4f31dd2570" visible="True" title="Version 4.1.2.0" />
+      <Topic id="05845fcc-1268-458b-a391-3d3fb1362115" visible="True" title="Version 4.1.3.0" />
     </Topic>
     <Topic id="be2ad779-f723-47b4-a6ab-00691c896a8e" visible="True" isExpanded="true" title="Hosting Extensions Version History">
       <Topic id="0677519c-d5ba-4c5d-b400-f10dc75a33a7" visible="True" title="Version 1.0.0.0" />
@@ -93,7 +96,8 @@
       <Topic id="39f4b138-eeba-4411-8cbc-ba4ee4163734" visible="True" title="Version 2.0.2.0" />
       <Topic id="e3907d72-92e2-49de-8c92-6969d124ef55" visible="True" title="Version 2.0.3.0" />
       <Topic id="3b4e306d-50ae-416e-8b47-8ca8f6caa2ae" visible="True" title="Version 2.0.4.0" />
-      <Topic id="4a56e6e7-8563-43f6-8653-394ddb5bb534" visible="True" isSelected="true" title="Version 2.0.5.0" />
+      <Topic id="4a56e6e7-8563-43f6-8653-394ddb5bb534" visible="True" title="Version 2.0.5.0" />
+      <Topic id="86cba777-87f7-4203-a004-1e5abf8e6254" visible="True" isSelected="true" title="Version 2.0.6.0" />
     </Topic>
   </Topic>
 </Topics>

--- a/Documentation/Documentation.shfbproj
+++ b/Documentation/Documentation.shfbproj
@@ -138,10 +138,13 @@
   <ItemGroup>
     <None Include="Content\VersionHistory\AntPlus\v6.0.4.0.aml" />
     <None Include="Content\VersionHistory\AntPlus\v6.1.0.0.aml" />
+    <None Include="Content\VersionHistory\AntPlus\v6.2.0.0.aml" />
     <None Include="Content\VersionHistory\AntRadioInterface\v5.0.2.0.aml" />
     <None Include="Content\VersionHistory\AntRadioInterface\v5.0.3.0.aml" />
+    <None Include="Content\VersionHistory\AntRadioInterface\v5.0.4.0.aml" />
     <None Include="Content\VersionHistory\AntUsbStick\v4.1.1.0.aml" />
     <None Include="Content\VersionHistory\AntUsbStick\v4.1.2.0.aml" />
+    <None Include="Content\VersionHistory\AntUsbStick\v4.1.3.0.aml" />
     <None Include="Content\VersionHistory\HostingExtensions\v2.0.3.0.aml" />
     <None Include="Content\VersionHistory\AntUsbStick\v4.1.0.0.aml" />
     <None Include="Content\VersionHistory\AntRadioInterface\v5.0.1.0.aml" />
@@ -207,6 +210,7 @@
     <None Include="Content\VersionHistory\HostingExtensions\v2.0.2.0.aml" />
     <None Include="Content\VersionHistory\HostingExtensions\v2.0.4.0.aml" />
     <None Include="Content\VersionHistory\HostingExtensions\v2.0.5.0.aml" />
+    <None Include="Content\VersionHistory\HostingExtensions\v2.0.6.0.aml" />
     <None Include="Content\VersionHistory\VersionHistory.aml" />
     <None Include="Content\Welcome.aml" />
   </ItemGroup>

--- a/Examples/AntUsbStick/AntUsbStick.csproj
+++ b/Examples/AntUsbStick/AntUsbStick.csproj
@@ -6,7 +6,7 @@
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <AssemblyName>SmallEarthTech.$(MSBuildProjectName)</AssemblyName>
     <Title>Garmin/Dynastream ANT+ USB Stick Class Library</Title>
-    <VersionPrefix>4.1.2</VersionPrefix>
+    <VersionPrefix>4.1.3</VersionPrefix>
 	<GeneratePackageOnBuild Condition="'$(Configuration)' == 'Release'">True</GeneratePackageOnBuild>
     <Authors>Stephen Hidem</Authors>
     <Description>Provides an interface to ANT+ USB sticks available from Garmin/Dynastream. This class is used in the example projects located at the project URL.</Description>

--- a/Examples/MAUI-gRPC/MauiAntGrpcClient/CustomAntDevice/BikeRadar.cs
+++ b/Examples/MAUI-gRPC/MauiAntGrpcClient/CustomAntDevice/BikeRadar.cs
@@ -126,7 +126,11 @@ namespace SmallEarthTech.AntPlus.DeviceProfiles
                     }
                     break;
                 default:
-                    CommonDataPages.ParseCommonDataPage(dataPage);
+                    // attempt to parse common data pages, if not successful raise unknown data page event
+                    if (!CommonDataPages.ParseCommonDataPage(dataPage))
+                    {
+                        OnUnknownDataPageReceived(dataPage);
+                    }
                     break;
             }
         }

--- a/Examples/WpfUsbStickApp/CustomAntDevice/BikeRadar.cs
+++ b/Examples/WpfUsbStickApp/CustomAntDevice/BikeRadar.cs
@@ -130,7 +130,11 @@ namespace SmallEarthTech.AntPlus.DeviceProfiles
                     }
                     break;
                 default:
-                    CommonDataPages.ParseCommonDataPage(dataPage);
+                    // attempt to parse common data pages, if not successful raise unknown data page event
+                    if (!CommonDataPages.ParseCommonDataPage(dataPage))
+                    {
+                        OnUnknownDataPageReceived(dataPage);
+                    }
                     break;
             }
         }

--- a/Extensions/Hosting/Hosting.UnitTests/Hosting.UnitTests.csproj
+++ b/Extensions/Hosting/Hosting.UnitTests/Hosting.UnitTests.csproj
@@ -15,7 +15,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
#### PR Classification
API enhancement to support custom/unknown ANT+ data pages and update dependencies.

#### PR Summary
This pull request adds the UnknownDataPageReceived event to the AntDevice class, enabling applications to handle unknown or custom data pages, and updates related parsing and tests. It also updates NuGet dependencies and documentation.
- AntDevice.cs: Introduces the UnknownDataPageReceived event and supporting methods for raising it.
- Device profile classes (e.g., BicyclePower, FitnessEquipment, HeartRate): Raise the event when unknown data pages are encountered during parsing.
- CommonDataPages.cs: Changes ParseCommonDataPage to return a bool for parse success/failure.
- Unit test files: Add and update tests to verify event raising and logging for unknown data pages.
- Project and documentation files: Update version numbers and document the new event.
