### PR TITLE
Update NuGet publish workflow and release notes

### DIFF
--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -15,6 +15,7 @@ jobs:
     permissions:
       contents: read
       actions: read
+      id-token: write
 
     steps:
     - uses: actions/checkout@v6
@@ -42,9 +43,16 @@ jobs:
     - name: Run Unit Tests
       run: dotnet test --no-build --verbosity minimal --configuration Github
 
+    # Get NuGet API Key
+    - name: Get NuGet API Key
+      uses: NuGet/login@v1
+      id: login
+      with:
+        user: ${{ secrets.NUGET_USER }}
+
     # Publish NuGet Packages
     - name: Publish NuGet Packages
-      run: dotnet nuget push **/*.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_API_KEY }} --skip-duplicate
+      run: dotnet nuget push **/*.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{steps.login.outputs.NUGET_API_KEY}} --skip-duplicate
 
     # Build Documentation and Upload Artifacts
     - name: Build Documentation

--- a/AntPlus.Extensions.Hosting/Hosting.csproj
+++ b/AntPlus.Extensions.Hosting/Hosting.csproj
@@ -17,8 +17,7 @@
 	<PackageIcon>PackageLogo.png</PackageIcon>
 	<PackageReadmeFile>readme.md</PackageReadmeFile>
 	<PackageReleaseNotes>
-		1. Removed ANT response logging due to noise.
-        2. Updated NuGet dependencies.
+		1. Dispose AntDevices when AntCollection is disposed.
     </PackageReleaseNotes>
 	<IncludeSymbols>True</IncludeSymbols>
 	<SymbolPackageFormat>snupkg</SymbolPackageFormat>


### PR DESCRIPTION
Switched to NuGet/login@v1 for secure API key handling in deploy-release.yml and updated dotnet nuget push to use the action output. Revised Hosting.csproj release notes to reflect AntDevices disposal with AntCollection and removed outdated notes.